### PR TITLE
Decoupled mutation rate controls, switching cache mutation rate to std::optional

### DIFF
--- a/AUTO_ARCH_SEARCH_GUIDE.md
+++ b/AUTO_ARCH_SEARCH_GUIDE.md
@@ -1008,3 +1008,21 @@ enum class Environment {
 | `examples/adaptive_mutation_demo.cpp` | Adaptive learning | Different configuration strategies |
 | `examples/adaptive_mutation_test.cpp` | System validation | Comprehensive testing suite |
 | `examples/simple_adaptive_test.cpp` | Quick validation | Core functionality verification |
+
+## Decoupled Mutation-Rate Policy (New)
+
+- Schedule-based updates: compute mutation rate every K generations; reuse cached value between updates.
+- Late-generation freeze: hold the last computed rate constant after a cutoff; operator selection continues to adapt.
+- Example CLI (example app):
+  - `--trials 20 --schedule 2 --freeze 4`
+  - `--trials 30 --schedule 0 --freeze 18446744073709551615` (every gen, no freeze)
+
+Observed behavior (quick summary):
+- With 20–30 trials, both fully-adaptive and decoupled policies reached ~99% preservation with tight CIs (~0.6–0.7%).
+- Decoupling stabilized mutation-rate trajectories while preserving operator learning.
+
+## Operator Analytics and Plots (New)
+
+- Each generation logs operator stats to `operator_stats.csv`: name, applications, success_rate, credit_score, probability, diversity, adaptive_rate.
+- Plotting script: `tools/plot_operator_stats.py` → outputs probability/credit/success trends and diversity vs. adaptive rate.
+- Per-run files: the example copies stats to `operator_stats_trials{N}_sched{K}_freeze{G}.csv` and appends a row to `run_summaries.csv`.

--- a/autoarchsearchwriteup.md
+++ b/autoarchsearchwriteup.md
@@ -59,6 +59,27 @@ The implemented system follows a sophisticated **layered architecture**:
 └─────────────────────────────────────────────────────────────┘
 ```
 
+### 7.2 Decoupled Mutation-Rate Policy Sep 7 2025
+
+We introduced an optional policy to decouple mutation-rate dynamics from operator learning:
+
+- Schedule-based updates: compute the mutation rate every K generations and reuse it between updates.
+- Freeze in late generations: hold the last computed mutation rate constant after a cutoff; mutation operators continue to adapt via credit updates.
+
+Practical usage (example app):
+- `--schedule 2 --freeze 4` updates at gens 1 and 3, then holds the rate steady.
+- Fully adaptive remains available with `--schedule 0 --freeze UINT64_MAX`.
+
+Observed behavior (20–30 trials):
+- Both policies routinely achieved ~99% preservation with tight confidence intervals (~0.6–0.7%).
+- Decoupling stabilized mutation-rate trajectories without degrading peak performance.
+
+### 7.3 Operator Analytics and Reproducibility Sep 7 2025
+
+- Per-generation operator stats are logged (applications, success rate, credit score, selection probability, diversity, adaptive rate).
+- A plotting utility (`tools/plot_operator_stats.py`) generates probability/credit/success trends and diversity vs. adaptive-rate plots.
+- The example writes per-run metadata to `run_summaries.csv` and copies operator stats to parameterized filenames for comparison.
+
 #### Adaptive Mutation System
 The framework implements a **multi-operator adaptive mutation controller** with five specialized genetic operators:
 

--- a/examples/auto_arch_search_example.cpp
+++ b/examples/auto_arch_search_example.cpp
@@ -69,16 +69,74 @@ int main(int argc, char** argv)
         size_t schedule_interval = 2;  // 0 = every gen
         size_t freeze_after_gen = 4;   // SIZE_MAX like behavior not needed here
 
-        // Parse super simple CLI: --trials N --schedule K --freeze G
-        for (int i = 1; i + 1 < argc; ++i) {
+        // Parse CLI: --trials N --schedule K --freeze G
+        bool trials_set = false, schedule_set = false, freeze_set = false;
+        for (int i = 1; i < argc; ++i) {
             if (std::strcmp(argv[i], "--trials") == 0) {
-                trials = static_cast<size_t>(std::stoul(argv[i + 1]));
+                if (trials_set) {
+                    std::cerr << "Error: --trials specified more than once.\n";
+                    std::exit(1);
+                }
+                if (i + 1 >= argc) {
+                    std::cerr << "Error: --trials requires a value.\n";
+                    std::exit(1);
+                }
+                try {
+                    trials = static_cast<size_t>(std::stoul(argv[i + 1]));
+                }
+                catch (...) {
+                    std::cerr << "Error: Invalid value for --trials: " << argv[i + 1] << "\n";
+                    std::exit(1);
+                }
+                trials_set = true;
+                ++i;
             }
             else if (std::strcmp(argv[i], "--schedule") == 0) {
-                schedule_interval = static_cast<size_t>(std::stoul(argv[i + 1]));
+                if (schedule_set) {
+                    std::cerr << "Error: --schedule specified more than once.\n";
+                    std::exit(1);
+                }
+                if (i + 1 >= argc) {
+                    std::cerr << "Error: --schedule requires a value.\n";
+                    std::exit(1);
+                }
+                try {
+                    schedule_interval = static_cast<size_t>(std::stoul(argv[i + 1]));
+                }
+                catch (...) {
+                    std::cerr << "Error: Invalid value for --schedule: " << argv[i + 1] << "\n";
+                    std::exit(1);
+                }
+                schedule_set = true;
+                ++i;
             }
             else if (std::strcmp(argv[i], "--freeze") == 0) {
-                freeze_after_gen = static_cast<size_t>(std::stoul(argv[i + 1]));
+                if (freeze_set) {
+                    std::cerr << "Error: --freeze specified more than once.\n";
+                    std::exit(1);
+                }
+                if (i + 1 >= argc) {
+                    std::cerr << "Error: --freeze requires a value.\n";
+                    std::exit(1);
+                }
+                try {
+                    freeze_after_gen = static_cast<size_t>(std::stoul(argv[i + 1]));
+                }
+                catch (...) {
+                    std::cerr << "Error: Invalid value for --freeze: " << argv[i + 1] << "\n";
+                    std::exit(1);
+                }
+                freeze_set = true;
+                ++i;
+            }
+            else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0) {
+                std::cout << "Usage: " << argv[0] << " [--trials N] [--schedule K] [--freeze G]\n";
+                std::exit(0);
+            }
+            else {
+                std::cerr << "Unknown argument: " << argv[i] << "\n";
+                std::cout << "Usage: " << argv[0] << " [--trials N] [--schedule K] [--freeze G]\n";
+                std::exit(1);
             }
         }
 
@@ -159,6 +217,8 @@ int main(int argc, char** argv)
                 std::ifstream src("operator_stats.csv", std::ios::binary);
                 std::ofstream dst(out_name, std::ios::binary);
                 dst << src.rdbuf();
+                // Truncate original to avoid stale data on subsequent runs
+                std::ofstream trunc("operator_stats.csv", std::ios::trunc);
             }
         }
 

--- a/examples/auto_arch_search_example.cpp
+++ b/examples/auto_arch_search_example.cpp
@@ -9,6 +9,8 @@
 #include <rad_ml/research/auto_arch_search.hpp>
 // Removing logger include that's causing build errors
 #include <cmath>
+#include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <random>
@@ -56,11 +58,29 @@ createSyntheticDataset(size_t train_size, size_t test_size, size_t input_size, s
     return {train_data, train_labels, test_data, test_labels};
 }
 
-int main()
+int main(int argc, char** argv)
 {
     try {
         std::cout << "🚀 RadML Auto Architecture Search Example\n";
         std::cout << "==========================================\n\n";
+
+        // Defaults
+        size_t trials = 10;
+        size_t schedule_interval = 2;  // 0 = every gen
+        size_t freeze_after_gen = 4;   // SIZE_MAX like behavior not needed here
+
+        // Parse super simple CLI: --trials N --schedule K --freeze G
+        for (int i = 1; i + 1 < argc; ++i) {
+            if (std::strcmp(argv[i], "--trials") == 0) {
+                trials = static_cast<size_t>(std::stoul(argv[i + 1]));
+            }
+            else if (std::strcmp(argv[i], "--schedule") == 0) {
+                schedule_interval = static_cast<size_t>(std::stoul(argv[i + 1]));
+            }
+            else if (std::strcmp(argv[i], "--freeze") == 0) {
+                freeze_after_gen = static_cast<size_t>(std::stoul(argv[i + 1]));
+            }
+        }
 
         // Create synthetic dataset with consistent dimensions
         auto [train_data, train_labels, test_data, test_labels] =
@@ -92,21 +112,55 @@ int main()
 
         // Enable adaptive mutation based on population diversity
         searcher.setAdaptiveMutation(true, 0.1, 0.3, 0.5, 0.01);
+        // Decouple policy: configurable schedule and freeze
+        searcher.setMutationRateSchedule(schedule_interval);
+        searcher.setMutationRateFreezeGeneration(freeze_after_gen);
 
         std::cout << "🧬 Starting evolutionary architecture search...\n";
         std::cout << "   Population size: 10\n";
         std::cout << "   Generations: 5\n";
-        std::cout << "   Monte Carlo trials: 3\n";
+        std::cout << "   Monte Carlo trials: 10\n";
         std::cout << "   Adaptive mutation: ENABLED\n\n";
 
         std::cout << "📊 Adaptive Mutation Parameters:\n";
         std::cout << "   Base rate: 0.1\n";
         std::cout << "   Diversity threshold: 0.3\n";
         std::cout << "   Max rate: 0.5\n";
-        std::cout << "   Min rate: 0.01\n\n";
+        std::cout << "   Min rate: 0.01\n";
+        std::cout << "   Schedule interval: " << schedule_interval << " generations\n";
+        std::cout << "   Freeze after generation: " << freeze_after_gen << "\n\n";
 
         // Run ONLY evolutionary search (remove random search)
-        auto result = searcher.evolutionarySearch(10, 5, 0.1, 5, true, 3);
+        auto result = searcher.evolutionarySearch(10, 5, 0.1, 5, true, trials);
+
+        // Save a per-run summary CSV (append)
+        {
+            std::ofstream summary("run_summaries.csv", std::ios::app);
+            if (summary.tellp() == 0) {
+                summary << "trials,schedule,freeze,baseline_acc,radiation_acc,preservation,"
+                        << "preservation_stddev,iterations\n";
+            }
+            summary << trials << "," << schedule_interval << "," << freeze_after_gen << ","
+                    << std::fixed << std::setprecision(2) << result.baseline_accuracy << ","
+                    << result.radiation_accuracy << "," << result.accuracy_preservation << ","
+                    << std::setprecision(3) << result.accuracy_preservation_stddev << ","
+                    << result.iterations << "\n";
+        }
+
+        // Rename operator_stats.csv to include parameters for comparison
+        // (the exporter writes to CWD; move if present)
+        {
+            std::ifstream test("operator_stats.csv");
+            if (test.good()) {
+                std::ostringstream name;
+                name << "operator_stats_trials" << trials << "_sched" << schedule_interval
+                     << "_freeze" << freeze_after_gen << ".csv";
+                std::string out_name = name.str();
+                std::ifstream src("operator_stats.csv", std::ios::binary);
+                std::ofstream dst(out_name, std::ios::binary);
+                dst << src.rdbuf();
+            }
+        }
 
         std::cout << "\n🎯 Search Results:\n";
         std::cout << "==================\n";

--- a/include/rad_ml/research/auto_arch_search.hpp
+++ b/include/rad_ml/research/auto_arch_search.hpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <rad_ml/neural/protected_neural_network.hpp>
 #include <rad_ml/research/architecture_tester.hpp>
 #include <rad_ml/sim/environment.hpp>
@@ -63,6 +64,8 @@ class AdaptiveMutationController {
     std::vector<MutationOperator> mutation_operators_;
     std::vector<double> operator_probabilities_;
     std::mt19937* random_generator_;
+    // Track last selected operator index for external accounting
+    size_t last_selected_operator_index_ = 0;
 
     // Learning parameters
     const double learning_rate_ = 0.1;
@@ -94,6 +97,11 @@ class AdaptiveMutationController {
     NetworkConfig adaptiveMutate(const NetworkConfig& config, double base_rate);
 
     /**
+     * @brief Get the index of the last mutation operator selected
+     */
+    size_t getLastSelectedOperatorIndex() const { return last_selected_operator_index_; }
+
+    /**
      * @brief Update operator credits based on fitness improvements
      * @param improvement_scores Vector of fitness improvements for recent mutations
      * @param used_operators Vector of operator indices used for those mutations
@@ -106,6 +114,16 @@ class AdaptiveMutationController {
      * @return Vector of operator statistics (name, applications, success_rate, credit_score)
      */
     std::vector<std::tuple<std::string, int, double, double>> getOperatorStatistics() const;
+
+    /**
+     * @brief Get current selection probabilities for mutation operators
+     */
+    std::vector<double> getOperatorProbabilities() const { return operator_probabilities_; }
+
+    /**
+     * @brief Get current exploration factor (epsilon) used for epsilon-greedy selection
+     */
+    double getExplorationFactor() const { return exploration_factor_; }
 
     /**
      * @brief Reset all operator statistics (useful for new evolutionary runs)
@@ -355,6 +373,22 @@ class AutoArchSearch {
                              double max_rate = 0.5, double min_rate = 0.01);
 
     /**
+     * @brief Decouple policy: compute mutation rate only every K generations (0 = every gen)
+     */
+    void setMutationRateSchedule(size_t schedule_interval)
+    {
+        mutation_rate_schedule_interval_ = schedule_interval;
+    }
+
+    /**
+     * @brief Decouple policy: freeze mutation rate after this generation index (SIZE_MAX = never)
+     */
+    void setMutationRateFreezeGeneration(size_t freeze_after_gen)
+    {
+        mutation_rate_freeze_after_gen_ = freeze_after_gen;
+    }
+
+    /**
      * @brief Get all tested configurations
      *
      * @return Map of configurations and their results
@@ -434,6 +468,11 @@ class AutoArchSearch {
 
     // Allow AdaptiveMutationController to access private members
     friend class AdaptiveMutationController;
+
+    // Decoupling controls
+    size_t mutation_rate_schedule_interval_ = 0;        // 0 = compute every generation
+    size_t mutation_rate_freeze_after_gen_ = SIZE_MAX;  // freeze never by default
+    std::optional<double> last_computed_mutation_rate_ = std::nullopt;  // cached rate
 
     /**
      * @brief Test a specific configuration

--- a/src/rad_ml/research/auto_arch_search.cpp
+++ b/src/rad_ml/research/auto_arch_search.cpp
@@ -12,6 +12,7 @@
 #include <numeric>
 #include <rad_ml/research/auto_arch_search.hpp>
 #include <set>
+#include <tuple>
 
 namespace rad_ml {
 namespace research {
@@ -301,9 +302,20 @@ SearchResult AutoArchSearch::evolutionarySearch(size_t population_size, size_t g
             }
         }
 
-        // Calculate adaptive mutation rate for this generation
-        double current_mutation_rate =
-            calculateAdaptiveMutationRate(population, fitness, gen, generations);
+        // Calculate adaptive mutation rate for this generation with decoupling controls
+        double current_mutation_rate;
+        const bool under_freeze = (gen >= mutation_rate_freeze_after_gen_);
+        const bool scheduled = (mutation_rate_schedule_interval_ == 0 ||
+                                (gen % mutation_rate_schedule_interval_ == 0));
+
+        if (!under_freeze && scheduled) {
+            current_mutation_rate =
+                calculateAdaptiveMutationRate(population, fitness, gen, generations);
+            last_computed_mutation_rate_ = current_mutation_rate;
+        }
+        else {
+            current_mutation_rate = last_computed_mutation_rate_.value_or(adaptive_base_rate_);
+        }
 
         if (adaptive_mutation_enabled_) {
             std::cout << "  Diversity: " << std::fixed << std::setprecision(3)
@@ -314,6 +326,9 @@ SearchResult AutoArchSearch::evolutionarySearch(size_t population_size, size_t g
 
         // Create new population through selection, crossover, and mutation
         std::vector<NetworkConfig> new_population;
+        // Track operator indices and improvements for adaptive credit updates
+        std::vector<size_t> used_operator_indices;
+        std::vector<double> operator_improvements;
 
         // Elitism: keep the best individual
         size_t best_idx =
@@ -337,8 +352,30 @@ SearchResult AutoArchSearch::evolutionarySearch(size_t population_size, size_t g
             // Crossover
             auto child = crossoverConfigs(population[parent1_idx], population[parent2_idx]);
 
+            // Record parent fitness for improvement calculation
+            double parent_fitness = std::max(fitness[parent1_idx], fitness[parent2_idx]);
+
             // Mutation with adaptive rate
             child = mutateConfig(child, current_mutation_rate);
+
+            // Track operator if adaptive controller used
+            if (adaptive_controller_ && adaptive_mutation_enabled_) {
+                used_operator_indices.push_back(
+                    adaptive_controller_->getLastSelectedOperatorIndex());
+            }
+            else {
+                // Use a sentinel index for basic mutation path
+                used_operator_indices.push_back(static_cast<size_t>(0));
+            }
+
+            // Evaluate child to compute improvement (cache-aware)
+            if (tested_configs_.count(child) == 0) {
+                auto result =
+                    testConfiguration(child, max_epochs, use_monte_carlo, monte_carlo_trials);
+                tested_configs_[child] = result;
+            }
+            double child_fitness = tested_configs_[child].accuracy_preservation;
+            operator_improvements.push_back(child_fitness - parent_fitness);
 
             // Add to new population
             new_population.push_back(child);
@@ -347,8 +384,60 @@ SearchResult AutoArchSearch::evolutionarySearch(size_t population_size, size_t g
         // Replace old population
         population = new_population;
 
+        // Update operator credits after generation
+        if (adaptive_controller_ && adaptive_mutation_enabled_ && !used_operator_indices.empty() &&
+            operator_improvements.size() == used_operator_indices.size()) {
+            adaptive_controller_->updateOperatorCredits(operator_improvements,
+                                                        used_operator_indices);
+
+            // Log operator learning progress per generation
+            auto stats = adaptive_controller_->getOperatorStatistics();
+            std::cout << "  Operator stats (gen " << (gen + 1) << "):" << std::endl;
+            std::cout << "    Name                Apps   Success   Credit" << std::endl;
+            for (const auto& entry : stats) {
+                const std::string& name = std::get<0>(entry);
+                int apps = static_cast<int>(std::get<1>(entry));
+                double success = std::get<2>(entry);
+                double credit = std::get<3>(entry);
+                std::cout << "    " << std::setw(18) << std::left << name << std::setw(7)
+                          << std::right << apps << "   " << std::fixed << std::setprecision(2)
+                          << std::setw(7) << success << "   " << std::fixed << std::setprecision(3)
+                          << std::setw(7) << credit << std::endl;
+            }
+        }
+
         // Save results for this generation
         saveResultsToFile();
+
+        // Append operator stats to CSV for analysis
+        if (adaptive_controller_ && adaptive_mutation_enabled_) {
+            static bool header_written = false;
+            std::ofstream op_out(
+                results_file_.empty() ? "operator_stats.csv" : "operator_stats.csv", std::ios::app);
+            if (op_out) {
+                if (!header_written) {
+                    op_out
+                        << "generation,operator,applications,success_rate,credit_score,probability,"
+                           "diversity,adaptive_rate\n";
+                    header_written = true;
+                }
+                auto stats = adaptive_controller_->getOperatorStatistics();
+                auto probs = adaptive_controller_->getOperatorProbabilities();
+                double diversity = calculatePopulationDiversity(population);
+                double adaptive_rate = current_mutation_rate;
+                for (size_t i = 0; i < stats.size(); ++i) {
+                    const auto& entry = stats[i];
+                    const std::string& name = std::get<0>(entry);
+                    int apps = static_cast<int>(std::get<1>(entry));
+                    double success = std::get<2>(entry);
+                    double credit = std::get<3>(entry);
+                    double prob = (i < probs.size()) ? probs[i] : 0.0;
+                    op_out << (gen + 1) << "," << name << "," << apps << "," << success << ","
+                           << credit << "," << prob << "," << diversity << "," << adaptive_rate
+                           << "\n";
+                }
+            }
+        }
     }
 
     // Return the best configuration found
@@ -1100,6 +1189,8 @@ NetworkConfig AdaptiveMutationController::adaptiveMutate(const NetworkConfig& co
     }
 
     size_t selected_operator = selectOperatorDynamically();
+    // Remember which operator was used for external accounting
+    last_selected_operator_index_ = selected_operator;
     NetworkConfig mutated = mutation_operators_[selected_operator].operator_func(config, base_rate);
 
     // Track operator usage

--- a/tools/plot_operator_stats.py
+++ b/tools/plot_operator_stats.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import os
+from collections import defaultdict
+
+
+def read_operator_stats(csv_path):
+    rows = []
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for r in reader:
+            # Coerce types
+            rows.append(
+                {
+                    "generation": int(r["generation"]),
+                    "operator": r["operator"],
+                    "applications": int(float(r["applications"])),
+                    "success_rate": float(r["success_rate"]),
+                    "credit_score": float(r["credit_score"]),
+                    "probability": float(r.get("probability", 0.0)),
+                    "diversity": float(r.get("diversity", 0.0)),
+                    "adaptive_rate": float(r.get("adaptive_rate", 0.0)),
+                }
+            )
+    return rows
+
+
+def pivot_by_operator(rows, field):
+    # returns: {operator: [(gen, value), ...]}
+    series = defaultdict(list)
+    for r in rows:
+        series[r["operator"]].append((r["generation"], r[field]))
+    # sort by generation
+    for op in series:
+        series[op].sort(key=lambda x: x[0])
+    return series
+
+
+def plot_lines(series_dict, title, ylabel, out_path):
+    try:
+        import matplotlib.pyplot as plt
+    except Exception as e:
+        print("matplotlib not available: {}".format(e))
+        print("Skipping plot:", out_path)
+        return
+
+    plt.figure(figsize=(8, 5))
+    for op, pts in series_dict.items():
+        if not pts:
+            continue
+        xs = [g for g, _ in pts]
+        ys = [v for _, v in pts]
+        plt.plot(xs, ys, marker="o", label=op)
+    plt.title(title)
+    plt.xlabel("Generation")
+    plt.ylabel(ylabel)
+    plt.grid(True, alpha=0.3)
+    plt.legend(loc="best")
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    plt.close()
+
+
+def plot_diversity_adaptive(rows, out_path):
+    try:
+        import matplotlib.pyplot as plt
+    except Exception as e:
+        print("matplotlib not available: {}".format(e))
+        print("Skipping plot:", out_path)
+        return
+
+    # group by generation (one row per operator; take first for diversity/rate)
+    gen_map = {}
+    for r in rows:
+        g = r["generation"]
+        if g not in gen_map:
+            gen_map[g] = (r["diversity"], r["adaptive_rate"])
+
+    gens = sorted(gen_map.keys())
+    diversity = [gen_map[g][0] for g in gens]
+    rate = [gen_map[g][1] for g in gens]
+
+    fig, ax1 = plt.subplots(figsize=(8, 5))
+    ax1.set_title("Diversity and Adaptive Mutation Rate")
+    ax1.set_xlabel("Generation")
+    ax1.set_ylabel("Diversity", color="tab:blue")
+    ax1.plot(gens, diversity, marker="o", color="tab:blue", label="Diversity")
+    ax1.tick_params(axis='y', labelcolor='tab:blue')
+
+    ax2 = ax1.twinx()
+    ax2.set_ylabel("Adaptive Rate", color="tab:orange")
+    ax2.plot(gens, rate, marker="s", color="tab:orange", label="Adaptive Rate")
+    ax2.tick_params(axis='y', labelcolor='tab:orange')
+
+    fig.tight_layout()
+    plt.savefig(out_path, dpi=150)
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Plot operator stats over generations")
+    parser.add_argument("--csv", required=True, help="Path to operator_stats.csv")
+    parser.add_argument("--outdir", required=True, help="Output directory for plots")
+    args = parser.parse_args()
+
+    rows = read_operator_stats(args.csv)
+    if not rows:
+        print("No rows found in:", args.csv)
+        return
+
+    os.makedirs(args.outdir, exist_ok=True)
+
+    # Per-operator time series
+    for field, title, ylabel, fname in [
+        ("probability", "Operator Selection Probability", "Probability", "operator_probabilities.png"),
+        ("credit_score", "Operator Credit Score", "Credit Score", "operator_credits.png"),
+        ("success_rate", "Operator Success Rate", "Success Rate", "operator_success.png"),
+    ]:
+        series = pivot_by_operator(rows, field)
+        plot_lines(series, title, ylabel, os.path.join(args.outdir, fname))
+
+    # Diversity + adaptive rate combo plot
+    plot_diversity_adaptive(rows, os.path.join(args.outdir, "diversity_adaptive_rate.png"))
+
+    print("Saved plots to:", args.outdir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary by Sourcery

Decouple and enrich the adaptive mutation subsystem: introduce schedule/freezing controls for mutation-rate updates, track and persist operator performance data, extend the example app and documentation for reproducible analytics, and add a plotting tool for visualizing operator statistics and diversity vs. adaptive-rate trends.

New Features:
- Introduce decoupled mutation-rate policy with configurable schedule and freeze settings
- Add operator analytics with per-generation tracking, console logging, and CSV export of mutation operator stats
- Enhance example CLI with --trials, --schedule, and --freeze flags and append run summaries to CSV

Enhancements:
- Cache adaptive mutation rate with std::optional and expose setMutationRateSchedule/setMutationRateFreezeGeneration APIs
- Automatically rename and archive operator_stats.csv based on run parameters

Documentation:
- Document decoupled mutation-rate policy and operator analytics in user guide and writeup