### PR TITLE
ECC Fixes: Hamming(8,4) SECDED Adaptive RS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,14 @@ add_executable(galois_field_bm_noheap_parity_test test/neural/galois_field_bm_no
 target_include_directories(galois_field_bm_noheap_parity_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 add_test(NAME galois_field_bm_noheap_parity_test COMMAND galois_field_bm_noheap_parity_test)
 
+add_executable(hamming_secded_test test/neural/hamming_secded_test.cpp)
+target_include_directories(hamming_secded_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+add_test(NAME hamming_secded_test COMMAND hamming_secded_test)
+
+# Verbose RS systematic-encoding diagnostic (manual inspection; not a strict regression test)
+add_executable(reed_solomon_fixed_diagnostic test/neural/reed_solomon_fixed_diagnostic.cpp)
+target_include_directories(reed_solomon_fixed_diagnostic PRIVATE ${CMAKE_SOURCE_DIR}/include)
+
 # Add executable for MultibitProtection RS integration testing
 add_executable(multibit_rs_test test/neural/multibit_rs_test.cpp)
 target_include_directories(multibit_rs_test PRIVATE ${CMAKE_SOURCE_DIR}/include)

--- a/include/rad_ml/neural/adaptive_protection.hpp
+++ b/include/rad_ml/neural/adaptive_protection.hpp
@@ -41,6 +41,13 @@ enum class AdaptiveProtectionLevel {
     ADAPTIVE    // Dynamically adjusted based on radiation conditions
 };
 
+/** Result of extended Hamming(8,4) SECDED decode for one 4-bit nibble */
+struct HammingDecodeResult {
+    uint8_t value = 0;
+    bool corrected = false;      ///< A single-bit error (including overall parity) was fixed
+    bool uncorrectable = false;  ///< Double-bit error detected; value is not trusted
+};
+
 // Note: Do NOT use 'using AdaptiveProtectionLevel = ...' here as it conflicts with
 // protected_neural_network.hpp
 
@@ -593,7 +600,7 @@ class AdaptiveProtection {
 
     /**
      * Apply Hamming protection - stores encoded data separately for full byte protection
-     * Uses two Hamming(7,4) codes per byte to protect all 8 bits
+     * Uses two Hamming(8,4) SECDED codes per byte to protect all 8 bits
      */
     template <typename U>
     U apply_hamming_protection(const U& value) const
@@ -617,8 +624,8 @@ class AdaptiveProtection {
     }
 
     /**
-     * Recover with Hamming error correction
-     * Uses stored encoded data to detect and correct single-bit errors per nibble
+     * Recover with Hamming SECDED error correction
+     * Uses stored encoded data to correct single-bit errors and detect double-bit errors
      */
     template <typename U>
     std::tuple<U, bool> recover_with_hamming(const U& value) const
@@ -640,20 +647,27 @@ class AdaptiveProtection {
             return {value, false};  // Size mismatch
         }
 
+        const uint8_t* value_bytes = reinterpret_cast<const uint8_t*>(&value);
         U result;
         uint8_t* result_bytes = reinterpret_cast<uint8_t*>(&result);
-        bool correction_applied = false;
+        bool event_detected = false;
 
         // Decode each byte
         for (size_t i = 0; i < sizeof(U); ++i) {
-            auto [decoded_byte, was_corrected] = hamming_decode_byte_full(encoded[i]);
-            result_bytes[i] = decoded_byte;
-            if (was_corrected) {
-                correction_applied = true;
+            auto [decoded_byte, was_corrected, uncorrectable] = hamming_decode_byte_full(encoded[i]);
+            if (uncorrectable) {
+                result_bytes[i] = value_bytes[i];
+                event_detected = true;
+            }
+            else {
+                result_bytes[i] = decoded_byte;
+                if (was_corrected) {
+                    event_detected = true;
+                }
             }
         }
 
-        return {result, correction_applied};
+        return {result, event_detected};
     }
 
     /**
@@ -667,65 +681,96 @@ class AdaptiveProtection {
     }
 
     /**
-     * Encode a single nibble (4 bits) using Hamming(7,4) code
-     * @param nibble Lower 4 bits of input
-     * @return 7-bit codeword
+     * Encode a single nibble (4 bits) using Hamming(7,4) core (7 data/parity bits)
+     * Layout: p1 p2 d1 p3 d2 d3 d4
      */
-    static uint8_t hamming_encode_nibble(uint8_t nibble)
+    static uint8_t hamming_encode_nibble_7_4(uint8_t nibble)
     {
         uint8_t d1 = (nibble >> 0) & 1;
         uint8_t d2 = (nibble >> 1) & 1;
         uint8_t d3 = (nibble >> 2) & 1;
         uint8_t d4 = (nibble >> 3) & 1;
 
-        // Calculate parity bits
         uint8_t p1 = d1 ^ d2 ^ d4;
         uint8_t p2 = d1 ^ d3 ^ d4;
         uint8_t p3 = d2 ^ d3 ^ d4;
 
-        // Construct codeword: p1 p2 d1 p3 d2 d3 d4 (7 bits)
         return (p1 << 0) | (p2 << 1) | (d1 << 2) | (p3 << 3) | (d2 << 4) | (d3 << 5) | (d4 << 6);
     }
 
-    /**
-     * Decode a 7-bit Hamming(7,4) codeword
-     * @param codeword 7-bit encoded value
-     * @return Tuple of (decoded 4-bit nibble, was_corrected)
-     */
-    static std::tuple<uint8_t, bool> hamming_decode_nibble(uint8_t codeword)
+    static uint8_t extract_nibble_from_codeword_7_4(uint8_t cw7)
     {
-        uint8_t p1 = (codeword >> 0) & 1;
-        uint8_t p2 = (codeword >> 1) & 1;
-        uint8_t d1 = (codeword >> 2) & 1;
-        uint8_t p3 = (codeword >> 3) & 1;
-        uint8_t d2 = (codeword >> 4) & 1;
-        uint8_t d3 = (codeword >> 5) & 1;
-        uint8_t d4 = (codeword >> 6) & 1;
-
-        // Calculate syndrome
-        uint8_t s1 = p1 ^ d1 ^ d2 ^ d4;
-        uint8_t s2 = p2 ^ d1 ^ d3 ^ d4;
-        uint8_t s3 = p3 ^ d2 ^ d3 ^ d4;
-
-        uint8_t error_pos = (s3 << 2) | (s2 << 1) | s1;
-
-        if (error_pos != 0 && error_pos <= 7) {
-            codeword ^= (1 << (error_pos - 1));
-            d1 = (codeword >> 2) & 1;
-            d2 = (codeword >> 4) & 1;
-            d3 = (codeword >> 5) & 1;
-            d4 = (codeword >> 6) & 1;
-        }
-
-        return {static_cast<uint8_t>((d1 << 0) | (d2 << 1) | (d3 << 2) | (d4 << 3)),
-                error_pos != 0};
+        uint8_t d1 = (cw7 >> 2) & 1;
+        uint8_t d2 = (cw7 >> 4) & 1;
+        uint8_t d3 = (cw7 >> 5) & 1;
+        uint8_t d4 = (cw7 >> 6) & 1;
+        return static_cast<uint8_t>((d1 << 0) | (d2 << 1) | (d3 << 2) | (d4 << 3));
     }
 
     /**
-     * Encode a full byte using two Hamming(7,4) codes
-     * Produces a 16-bit codeword (2 bytes) to protect all 8 bits
+     * Encode a single nibble using extended Hamming(8,4) SECDED
+     * @param nibble Lower 4 bits of input
+     * @return 8-bit codeword (bit 7 = overall parity of bits 0-6)
+     */
+    static uint8_t hamming_encode_nibble(uint8_t nibble)
+    {
+        uint8_t cw7 = hamming_encode_nibble_7_4(nibble);
+        uint8_t p0 = 0;
+        for (int i = 0; i < 7; ++i) {
+            p0 ^= static_cast<uint8_t>((cw7 >> i) & 1);
+        }
+        return static_cast<uint8_t>(cw7 | (p0 << 7));
+    }
+
+    /**
+     * Decode an 8-bit Hamming(8,4) SECDED codeword
+     * Corrects single-bit errors; detects (does not miscorrect) double-bit errors
+     */
+    static HammingDecodeResult hamming_decode_nibble(uint8_t codeword)
+    {
+        uint8_t overall = 0;
+        for (int i = 0; i < 8; ++i) {
+            overall ^= static_cast<uint8_t>((codeword >> i) & 1);
+        }
+
+        uint8_t cw7 = codeword & 0x7F;
+        uint8_t p1 = (cw7 >> 0) & 1;
+        uint8_t p2 = (cw7 >> 1) & 1;
+        uint8_t d1 = (cw7 >> 2) & 1;
+        uint8_t p3 = (cw7 >> 3) & 1;
+        uint8_t d2 = (cw7 >> 4) & 1;
+        uint8_t d3 = (cw7 >> 5) & 1;
+        uint8_t d4 = (cw7 >> 6) & 1;
+
+        uint8_t s1 = static_cast<uint8_t>(p1 ^ d1 ^ d2 ^ d4);
+        uint8_t s2 = static_cast<uint8_t>(p2 ^ d1 ^ d3 ^ d4);
+        uint8_t s3 = static_cast<uint8_t>(p3 ^ d2 ^ d3 ^ d4);
+        uint8_t syndrome = static_cast<uint8_t>((s3 << 2) | (s2 << 1) | s1);
+
+        if (syndrome == 0 && overall == 0) {
+            return {extract_nibble_from_codeword_7_4(cw7), false, false};
+        }
+
+        if (syndrome != 0 && overall == 1) {
+            if (syndrome <= 7) {
+                cw7 ^= static_cast<uint8_t>(1u << (syndrome - 1));
+            }
+            return {extract_nibble_from_codeword_7_4(cw7), true, false};
+        }
+
+        if (syndrome == 0 && overall == 1) {
+            // Error confined to overall parity bit (position 8); data bits are intact
+            return {extract_nibble_from_codeword_7_4(cw7), true, false};
+        }
+
+        // syndrome != 0 && overall == 0: double-bit error
+        return {extract_nibble_from_codeword_7_4(cw7), false, true};
+    }
+
+    /**
+     * Encode a full byte using two Hamming(8,4) SECDED codes
      * @param data Full 8-bit byte to encode
-     * @return 16-bit codeword (lower 7 bits = lower nibble, upper 7 bits = upper nibble)
+     * @return 16-bit codeword (low/high bytes each hold one 8-bit SECDED nibble code)
      */
     static uint16_t hamming_encode_byte_full(uint8_t data)
     {
@@ -739,29 +784,28 @@ class AdaptiveProtection {
     }
 
     /**
-     * Decode a 16-bit Hamming-encoded byte
-     * @param codeword 16-bit encoded value
-     * @return Tuple of (decoded byte, was_corrected)
+     * Decode a 16-bit SECDED Hamming-encoded byte
+     * @return Tuple of (decoded byte, single-bit corrected, double-bit detected)
      */
-    static std::tuple<uint8_t, bool> hamming_decode_byte_full(uint16_t codeword)
+    static std::tuple<uint8_t, bool, bool> hamming_decode_byte_full(uint16_t codeword)
     {
-        auto [low_nibble, low_corrected] = hamming_decode_nibble(codeword & 0x7F);
-        auto [high_nibble, high_corrected] = hamming_decode_nibble((codeword >> 8) & 0x7F);
+        auto low = hamming_decode_nibble(static_cast<uint8_t>(codeword & 0xFF));
+        auto high = hamming_decode_nibble(static_cast<uint8_t>((codeword >> 8) & 0xFF));
 
-        uint8_t data = low_nibble | (high_nibble << 4);
-        return {data, low_corrected || high_corrected};
+        uint8_t data = static_cast<uint8_t>(low.value | (high.value << 4));
+        return {data, low.corrected || high.corrected, low.uncorrectable || high.uncorrectable};
     }
 
-    // Legacy single-nibble functions for backward compatibility
+    // Legacy single-nibble API (lower 4 bits only)
     static uint8_t hamming_encode_byte(uint8_t data)
     {
-        // Note: This only protects lower 4 bits - use hamming_encode_byte_full for full protection
         return hamming_encode_nibble(data & 0x0F);
     }
 
     static std::tuple<uint8_t, bool> hamming_decode_byte(uint8_t codeword)
     {
-        return hamming_decode_nibble(codeword);
+        auto result = hamming_decode_nibble(codeword);
+        return {result.value, result.corrected};
     }
 
    private:

--- a/include/rad_ml/neural/advanced_reed_solomon.hpp
+++ b/include/rad_ml/neural/advanced_reed_solomon.hpp
@@ -184,8 +184,8 @@ class AdvancedReedSolomon {
         // Calculate syndromes
         auto syndromes = field_.rs_calc_syndromes(codeword, ECCSymbols);
 
-        // Check if all syndromes are zero (no errors)
-        for (size_t i = 1; i < syndromes.size(); ++i) {
+        // Check codeword syndromes at roots α^0..α^{nsym-1} (exclude syndromes[nsym])
+        for (size_t i = 0; i < static_cast<size_t>(ECCSymbols); ++i) {
             if (syndromes[i] != 0) {
                 // Errors detected, check if they're correctable
 #if RADML_RS_BM_NOHEAP

--- a/include/rad_ml/neural/galois_field.hpp
+++ b/include/rad_ml/neural/galois_field.hpp
@@ -193,7 +193,10 @@ class GaloisField {
      *
      * @param msg Message with ecc symbols
      * @param nsym Number of ecc symbols
-     * @return Syndrome values (first value is always 0)
+     * @return Syndrome values (size nsym+1). Indexing convention used by this codec:
+     *         syndromes[i] = r(α^i) for i = 0..nsym. Valid codewords have
+     *         syndromes[0]..syndromes[nsym-1] = 0 (roots of g(x)); syndromes[nsym]
+     *         may be nonzero even on valid codewords and is not used for detection.
      */
     std::vector<element_t> rs_calc_syndromes(const std::vector<element_t>& msg, uint8_t nsym) const
     {
@@ -240,7 +243,7 @@ class GaloisField {
      *
      * where S(x) = S₁x + S₂x² + … collects the nonzero syndromes.
      *
-     * @param syndromes Syndromes from rs_calc_syndromes (size nsym+1; syndromes[0]==0)
+     * @param syndromes Syndromes from rs_calc_syndromes (size nsym+1; BM uses syndromes[1..nsym])
      * @param nsym Number of ECC symbols (designed correction capacity is nsym/2)
      * @return Tuple {Λ(x), Ω(x)} as vectors of coefficients (highest degree first)
      */
@@ -570,9 +573,10 @@ class GaloisField {
         // Calculate syndromes
         auto syndromes = rs_calc_syndromes(msg, nsym);
 
-        // Nonzero in S_1..S_{nsym-1} indicates errors (S_nsym is not a codeword root here).
+        // Nonzero in syndromes[0]..syndromes[nsym-1] indicates errors.
+        // syndromes[nsym] is not a root of g(x) and may be nonzero on valid codewords.
         bool has_errors = false;
-        for (size_t i = 1; i < static_cast<size_t>(nsym); ++i) {
+        for (size_t i = 0; i < static_cast<size_t>(nsym); ++i) {
             if (syndromes[i] != 0) {
                 has_errors = true;
                 break;

--- a/test/neural/galois_field_bm_noheap_parity_test.cpp
+++ b/test/neural/galois_field_bm_noheap_parity_test.cpp
@@ -124,8 +124,8 @@ static bool round_trip_decode(std::mt19937& rng, int trials, const char* label)
             codew[i] = enc[i];
         }
 
-        // Random error count: small codes use k < min(t,4); long RS(8,16)+ uses k in {0,1,2} only
-        // (this decoder + random XOR/positions is not reliable for higher weight on long codewords).
+        // Random error count. RS(8,16) on short codewords (e.g. uint8_t → 17 symbols): BM path
+        // is validated through k<=3 in random XOR trials; k>=4 can fail (trial 0 k=4 reproduces).
         unsigned k_cap;
         if constexpr (Ecc >= 16) {
             k_cap = 3u;
@@ -248,7 +248,7 @@ int main()
     if (!round_trip_exactly_t_errors<uint8_t, 16>("uint8_t RS(8,16)")) {
         return 1;
     }
-    std::cout << "OK decode RS(8,16) tail stress (<=3 tail flips; long-code cap)\n";
+    std::cout << "OK decode RS(8,16) tail stress (<=3 tail flips; short-codecap)\n";
 
     if (!round_trip_decode<uint32_t, 8>(rng, 2000, "uint32_t RS(8,8)")) {
         return 1;

--- a/test/neural/hamming_secded_test.cpp
+++ b/test/neural/hamming_secded_test.cpp
@@ -1,0 +1,117 @@
+/**
+ * @file hamming_secded_test.cpp
+ * @brief Validates Hamming(8,4) SECDED encode/decode in AdaptiveProtection
+ */
+
+#include <cstdint>
+#include <iostream>
+
+#include "../../include/rad_ml/neural/adaptive_protection.hpp"
+
+using rad_ml::neural::AdaptiveProtection;
+using rad_ml::neural::HammingDecodeResult;
+
+static bool check(bool cond, const char* msg)
+{
+    if (!cond) {
+        std::cerr << "FAIL: " << msg << "\n";
+    }
+    return cond;
+}
+
+static void flip_bit(uint8_t& cw, int bit)
+{
+    cw ^= static_cast<uint8_t>(1u << bit);
+}
+
+static bool test_round_trip_all_nibbles()
+{
+    for (unsigned n = 0; n < 16; ++n) {
+        uint8_t enc = AdaptiveProtection<float>::hamming_encode_nibble(static_cast<uint8_t>(n));
+        HammingDecodeResult dec = AdaptiveProtection<float>::hamming_decode_nibble(enc);
+        if (!check(dec.value == n && !dec.corrected && !dec.uncorrectable,
+                   "clean round-trip nibble")) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool test_single_bit_correction()
+{
+    for (unsigned n = 0; n < 16; ++n) {
+        uint8_t enc = AdaptiveProtection<float>::hamming_encode_nibble(static_cast<uint8_t>(n));
+        for (int bit = 0; bit < 8; ++bit) {
+            uint8_t corrupted = enc;
+            flip_bit(corrupted, bit);
+            HammingDecodeResult dec = AdaptiveProtection<float>::hamming_decode_nibble(corrupted);
+            if (!check(dec.value == n && dec.corrected && !dec.uncorrectable,
+                       "single-bit correction")) {
+                std::cerr << "  n=" << n << " bit=" << bit << "\n";
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+static bool test_double_bit_detection()
+{
+    uint8_t enc = AdaptiveProtection<float>::hamming_encode_nibble(0xA);
+    int failures = 0;
+    int detected = 0;
+
+    for (int b1 = 0; b1 < 8; ++b1) {
+        for (int b2 = b1 + 1; b2 < 8; ++b2) {
+            uint8_t corrupted = enc;
+            flip_bit(corrupted, b1);
+            flip_bit(corrupted, b2);
+            HammingDecodeResult dec = AdaptiveProtection<float>::hamming_decode_nibble(corrupted);
+            ++failures;
+            if (dec.uncorrectable) {
+                ++detected;
+            }
+            else if (dec.corrected && dec.value == 0xA) {
+                // Recovered original without uncorrectable flag — still acceptable if data matches
+                ++detected;
+            }
+        }
+    }
+
+    if (!check(detected == failures, "all double-bit patterns flagged or safely handled")) {
+        std::cerr << "  detected " << detected << " / " << failures << "\n";
+        return false;
+    }
+    return true;
+}
+
+static bool test_byte_full_path()
+{
+    uint8_t data = 0x5A;
+    uint16_t enc = AdaptiveProtection<float>::hamming_encode_byte_full(data);
+    auto [decoded, corrected, uncorrectable] =
+        AdaptiveProtection<float>::hamming_decode_byte_full(enc);
+    if (!check(decoded == data && !corrected && !uncorrectable, "byte full clean")) {
+        return false;
+    }
+
+    uint16_t corrupted = enc ^ 0x0004u;
+    auto [fixed, was_corrected, dbl] =
+        AdaptiveProtection<float>::hamming_decode_byte_full(corrupted);
+    return check(fixed == data && was_corrected && !dbl, "byte full single-bit fix");
+}
+
+int main()
+{
+    bool ok = true;
+    ok = test_round_trip_all_nibbles() && ok;
+    ok = test_single_bit_correction() && ok;
+    ok = test_double_bit_detection() && ok;
+    ok = test_byte_full_path() && ok;
+
+    if (ok) {
+        std::cout << "All hamming_secded_test checks passed.\n";
+        return 0;
+    }
+    return 1;
+}

--- a/test/neural/reed_solomon_fixed_diagnostic.cpp
+++ b/test/neural/reed_solomon_fixed_diagnostic.cpp
@@ -1,13 +1,16 @@
 /**
  * @file reed_solomon_fixed_diagnostic.cpp
- * @brief Test the CORRECTED Reed-Solomon systematic encoding algorithm
+ * @brief Manual diagnostic: RS systematic encoding, syndromes, and single-error correction
+ *
+ * Verbose step-by-step output for debugging GF(256) encode/decode. Run directly;
+ * not an automated pass/fail regression test (see galois_field_bm_noheap_parity_test).
  */
 
 #include <iomanip>
 #include <iostream>
 #include <vector>
 
-#include "include/rad_ml/neural/galois_field.hpp"
+#include "../../include/rad_ml/neural/galois_field.hpp"
 
 using namespace rad_ml::neural;
 
@@ -188,11 +191,10 @@ int main()
         }
 
         // Check if the relevant syndromes are zero
-        // For Reed-Solomon codes with generator polynomial having roots at α⁰, α¹, ..., α^(nsym-1)
-        // We check syndromes S₁ through S_(nsym-1), but NOT S_nsym
+        // Generator roots at α⁰..α^(nsym-1) → syndromes[0]..syndromes[nsym-1] must be zero
         bool all_relevant_zero = true;
-        std::cout << "    Checking relevant syndromes S₁ through S" << (nsym - 1) << ":\n";
-        for (size_t i = 1; i < nsym; ++i) {
+        std::cout << "    Checking syndromes S₀ through S" << (nsym - 1) << ":\n";
+        for (size_t i = 0; i < static_cast<size_t>(nsym); ++i) {
             std::cout << "      S" << i << " = " << std::hex << (int)syndromes[i] << std::dec;
             if (syndromes[i] != 0) {
                 all_relevant_zero = false;
@@ -214,7 +216,7 @@ int main()
             std::cout << "    ✓ SUCCESS: All relevant syndromes are zero - VALID CODEWORD!\n";
         }
         else {
-            std::cout << "    ✗ FAILURE: Non-zero syndromes detected in S₁ through S" << nsym
+            std::cout << "    ✗ FAILURE: Non-zero syndromes detected in S₀ through S" << (int)nsym - 1
                       << "\n";
         }
 
@@ -254,7 +256,6 @@ int main()
         }
         std::cout << std::dec << "\n";
 
-        // Test if error correction works (it may fail due to the S₄ issue)
         auto corrected = gf.rs_correct_errors(corrupted, nsym);
         if (corrected.has_value()) {
             std::cout << "    ✓ Error correction succeeded!\n";


### PR DESCRIPTION
## Summary by Sourcery

Implement extended Hamming(8,4) SECDED protection and refine Reed-Solomon syndrome handling and diagnostics.

New Features:
- Add Hamming(8,4) SECDED encoding/decoding with explicit decode result struct and integrate it into AdaptiveProtection byte-level protection.
- Introduce a manual Reed-Solomon diagnostic executable for step-by-step inspection of systematic encoding and error correction.
- Add an automated hamming_secded_test executable to validate SECDED behavior across nibbles and bytes.

Bug Fixes:
- Correct Reed-Solomon syndrome indexing and error-detection logic to use syndromes at roots α⁰..α^(nsym-1) consistently across the codec and tests.
- Prevent miscorrection on Hamming-encoded data by distinguishing single-bit corrections from double-bit uncorrectable errors and preserving original data on uncorrectable events.

Enhancements:
- Clarify documentation and comments for Reed-Solomon syndrome conventions and Berlekamp–Massey usage.
- Refine Galois-field BM parity tests to more accurately describe and constrain tested error patterns.
- Improve AdaptiveProtection legacy Hamming API behavior while routing through the new SECDED implementation.

Tests:
- Extend the RS BM no-heap parity tests and add coverage for SECDED Hamming encoding/decoding, including single-bit correction and double-bit detection.