### PR TITLE
Very High RS-16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,10 @@ add_test(NAME hamming_secded_test COMMAND hamming_secded_test)
 add_executable(reed_solomon_fixed_diagnostic test/neural/reed_solomon_fixed_diagnostic.cpp)
 target_include_directories(reed_solomon_fixed_diagnostic PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
+# Syndrome-indexing / RS(8,16) k=4 probe (manual; not CTest)
+add_executable(syndrome_index_probe test/neural/syndrome_index_probe.cpp)
+target_include_directories(syndrome_index_probe PRIVATE ${CMAKE_SOURCE_DIR}/include)
+
 # Add executable for MultibitProtection RS integration testing
 add_executable(multibit_rs_test test/neural/multibit_rs_test.cpp)
 target_include_directories(multibit_rs_test PRIVATE ${CMAKE_SOURCE_DIR}/include)

--- a/include/rad_ml/neural/galois_field.hpp
+++ b/include/rad_ml/neural/galois_field.hpp
@@ -241,9 +241,9 @@ class GaloisField {
      *
      *   Ω(x) = (S(x) · Λ(x)) mod x^{nsym},
      *
-     * where S(x) = S₁x + S₂x² + … collects the nonzero syndromes.
+     * where S(x) = S₀ + S₁x + S₂x² + … with S_i = syndromes[i].
      *
-     * @param syndromes Syndromes from rs_calc_syndromes (size nsym+1; BM uses syndromes[1..nsym])
+     * @param syndromes Syndromes from rs_calc_syndromes (size nsym+1; BM uses syndromes[0..nsym-1])
      * @param nsym Number of ECC symbols (designed correction capacity is nsym/2)
      * @return Tuple {Λ(x), Ω(x)} as vectors of coefficients (highest degree first)
      */
@@ -261,12 +261,11 @@ class GaloisField {
         size_t shift = 1;                // Number of iterations since L changed
 
         for (uint8_t n = 0; n < nsym; ++n) {
-            // Compute discrepancy: d = S_{n+1} + Σ_{i=1}^{L} C_i * S_{n+1-i}
-            // d = S_{n+1} + sum_{i=1}^{L} C_i S_{n+1-i}; bound by L (Massey), coeffs by C.size().
-            element_t d = syndromes[n + 1];
+            // Compute discrepancy: d = S_n + Σ_{i=1}^{L} C_i * S_{n-i}
+            element_t d = syndromes[n];
             for (size_t i = 1; i <= L; ++i) {
-                if (i < C.size() && n + 1 >= i) {
-                    d = add(d, multiply(C[i], syndromes[n + 1 - i]));
+                if (i < C.size() && n >= i) {
+                    d = add(d, multiply(C[i], syndromes[n - i]));
                 }
             }
 
@@ -310,13 +309,12 @@ class GaloisField {
         }
 
         // Compute error evaluator Ω(x) = S(x) * Λ(x) mod x^nsym
-        // where S(x) = S_1 + S_2*x + S_3*x^2 + ...
+        // where S(x) = S_0 + S_1*x + S_2*x^2 + ...
         std::vector<element_t> omega(nsym, 0);
         for (size_t i = 0; i < nsym; ++i) {
             for (size_t j = 0; j < C.size() && j <= i; ++j) {
-                // S(x) has S_1 at x^0, S_2 at x^1, etc., so syndromes[j+1]
-                if (i - j + 1 < syndromes.size()) {
-                    omega[i] = add(omega[i], multiply(C[j], syndromes[i - j + 1]));
+                if (i >= j) {
+                    omega[i] = add(omega[i], multiply(C[j], syndromes[i - j]));
                 }
             }
         }
@@ -389,11 +387,11 @@ class GaloisField {
         size_t shift = 1;
 
         for (uint8_t n = 0; n < nsym; ++n) {
-            // d = S_{n+1} + sum_{i=1}^{L} C_i S_{n+1-i}; bound recurrence by L (Massey), coeffs by len.
-            element_t d = syndromes[n + 1];
+            // d = S_n + sum_{i=1}^{L} C_i S_{n-i}
+            element_t d = syndromes[n];
             for (size_t i = 1; i <= L; ++i) {
-                if (i < C.len && n + 1 >= i) {
-                    d = add(d, multiply(C.data[i], syndromes[n + 1 - i]));
+                if (i < C.len && n >= i) {
+                    d = add(d, multiply(C.data[i], syndromes[n - i]));
                 }
             }
 
@@ -429,8 +427,8 @@ class GaloisField {
         std::vector<element_t> omega(nsym, 0);
         for (size_t i = 0; i < nsym; ++i) {
             for (size_t j = 0; j < C.len && j <= i; ++j) {
-                if (i - j + 1 < syndromes.size()) {
-                    omega[i] = add(omega[i], multiply(C.data[j], syndromes[i - j + 1]));
+                if (i >= j) {
+                    omega[i] = add(omega[i], multiply(C.data[j], syndromes[i - j]));
                 }
             }
         }

--- a/include/rad_ml/neural/galois_field.hpp
+++ b/include/rad_ml/neural/galois_field.hpp
@@ -250,76 +250,11 @@ class GaloisField {
     std::tuple<std::vector<element_t>, std::vector<element_t>> rs_find_error_locator(
         const std::vector<element_t>& syndromes, uint8_t nsym) const
     {
-        // Berlekamp-Massey algorithm (standard lowest-degree-first convention)
-        // Λ(x) = Λ_0 + Λ_1*x + Λ_2*x^2 + ..., stored as [Λ_0, Λ_1, Λ_2, ...]
-        // Initial: Λ = [1] (constant 1)
-
-        std::vector<element_t> C = {1};  // Current error locator Λ(x)
-        std::vector<element_t> B = {1};  // Previous error locator (backup)
-        size_t L = 0;                    // Current number of assumed errors
-        element_t b_prev = 1;            // Previous discrepancy
-        size_t shift = 1;                // Number of iterations since L changed
-
-        for (uint8_t n = 0; n < nsym; ++n) {
-            // Compute discrepancy: d = S_n + Σ_{i=1}^{L} C_i * S_{n-i}
-            element_t d = syndromes[n];
-            for (size_t i = 1; i <= L; ++i) {
-                if (i < C.size() && n >= i) {
-                    d = add(d, multiply(C[i], syndromes[n - i]));
-                }
-            }
-
-            if (d == 0) {
-                // No change needed
-                shift++;
-            }
-            else {
-                // T(x) = C(x) - (d/b) * x^shift * B(x)
-                std::vector<element_t> T = C;
-                element_t coeff = divide(d, b_prev);
-
-                // Ensure T is large enough
-                if (T.size() < B.size() + shift) {
-                    T.resize(B.size() + shift, 0);
-                }
-
-                // T = C - coeff * x^shift * B
-                for (size_t i = 0; i < B.size(); ++i) {
-                    T[i + shift] = add(T[i + shift], multiply(coeff, B[i]));
-                }
-
-                if (2 * L <= n) {
-                    // Increase L
-                    L = n + 1 - L;
-                    B = C;
-                    b_prev = d;
-                    shift = 1;
-                }
-                else {
-                    shift++;
-                }
-
-                C = T;
-            }
-        }
-
-        // Trim trailing zeros from C
-        while (C.size() > 1 && C.back() == 0) {
-            C.pop_back();
-        }
-
-        // Compute error evaluator Ω(x) = S(x) * Λ(x) mod x^nsym
-        // where S(x) = S_0 + S_1*x + S_2*x^2 + ...
-        std::vector<element_t> omega(nsym, 0);
-        for (size_t i = 0; i < nsym; ++i) {
-            for (size_t j = 0; j < C.size() && j <= i; ++j) {
-                if (i >= j) {
-                    omega[i] = add(omega[i], multiply(C[j], syndromes[i - j]));
-                }
-            }
-        }
-
-        return {C, omega};
+        BmHeapPoly C;
+        BmHeapPoly B;
+        rs_bm_locator_loop(syndromes, nsym, C, B);
+        auto locator = C.to_vector();
+        return {locator, rs_bm_compute_omega(locator, syndromes, nsym)};
     }
 
     /**
@@ -332,108 +267,11 @@ class GaloisField {
     std::tuple<std::vector<element_t>, std::vector<element_t>> rs_find_error_locator_noheap(
         const std::vector<element_t>& syndromes, uint8_t nsym) const
     {
-        struct PolyBuf {
-            std::array<element_t, k_rs_bm_poly_cap> data{};
-            size_t len = 0;
-
-            static PolyBuf one()
-            {
-                PolyBuf p;
-                p.data[0] = 1;
-                p.len = 1;
-                return p;
-            }
-
-            void copy_from(const PolyBuf& o)
-            {
-                const size_t prev = len;
-                for (size_t i = 0; i < o.len; ++i) {
-                    data[i] = o.data[i];
-                }
-                // Clear slots we no longer own (fixed buffer); avoids stale coeffs if len grows again.
-                for (size_t i = o.len; i < prev; ++i) {
-                    data[i] = 0;
-                }
-                len = o.len;
-            }
-
-            void ensure_len_at_least(size_t new_len, element_t fill)
-            {
-                if (new_len > k_rs_bm_poly_cap) {
-                    throw std::length_error("rs_find_error_locator_noheap: polynomial capacity exceeded");
-                }
-                while (len < new_len) {
-                    data[len++] = fill;
-                }
-            }
-
-            void trim_trailing_zeros()
-            {
-                while (len > 1 && data[len - 1] == 0) {
-                    --len;
-                }
-            }
-
-            std::vector<element_t> to_vector() const
-            {
-                return std::vector<element_t>(data.begin(), data.begin() + static_cast<std::ptrdiff_t>(len));
-            }
-        };
-
-        PolyBuf C = PolyBuf::one();
-        PolyBuf B = PolyBuf::one();
-        size_t L = 0;
-        element_t b_prev = 1;
-        size_t shift = 1;
-
-        for (uint8_t n = 0; n < nsym; ++n) {
-            // d = S_n + sum_{i=1}^{L} C_i S_{n-i}
-            element_t d = syndromes[n];
-            for (size_t i = 1; i <= L; ++i) {
-                if (i < C.len && n >= i) {
-                    d = add(d, multiply(C.data[i], syndromes[n - i]));
-                }
-            }
-
-            if (d == 0) {
-                shift++;
-            } else {
-                PolyBuf T;
-                T.copy_from(C);
-                element_t coeff = divide(d, b_prev);
-
-                const size_t need_len = B.len + shift;
-                T.ensure_len_at_least(need_len, 0);
-
-                for (size_t i = 0; i < B.len; ++i) {
-                    T.data[i + shift] = add(T.data[i + shift], multiply(coeff, B.data[i]));
-                }
-
-                if (2 * L <= n) {
-                    L = n + 1 - L;
-                    B.copy_from(C);
-                    b_prev = d;
-                    shift = 1;
-                } else {
-                    shift++;
-                }
-
-                C.copy_from(T);
-            }
-        }
-
-        C.trim_trailing_zeros();
-
-        std::vector<element_t> omega(nsym, 0);
-        for (size_t i = 0; i < nsym; ++i) {
-            for (size_t j = 0; j < C.len && j <= i; ++j) {
-                if (i >= j) {
-                    omega[i] = add(omega[i], multiply(C.data[j], syndromes[i - j]));
-                }
-            }
-        }
-
-        return {C.to_vector(), omega};
+        BmStackPoly C;
+        BmStackPoly B;
+        rs_bm_locator_loop(syndromes, nsym, C, B);
+        auto locator = C.to_vector();
+        return {locator, rs_bm_compute_omega(locator, syndromes, nsym)};
     }
 
     /**
@@ -796,6 +634,131 @@ class GaloisField {
    private:
     /// Max coefficients for no-heap BM temporary polynomials (shift + degree bound).
     static constexpr size_t k_rs_bm_poly_cap = 256;
+
+    /** Heap-backed Λ(x) buffer for Berlekamp–Massey (lowest-degree-first). */
+    struct BmHeapPoly {
+        std::vector<element_t> data{1};
+
+        size_t len() const { return data.size(); }
+        element_t at(size_t i) const { return data[i]; }
+        void ensure_len(size_t n)
+        {
+            if (data.size() < n) {
+                data.resize(n, 0);
+            }
+        }
+        void add_at(size_t i, element_t v) { data[i] = static_cast<element_t>(data[i] ^ v); }
+        void copy_from(const BmHeapPoly& o) { data = o.data; }
+        void trim()
+        {
+            while (data.size() > 1 && data.back() == 0) {
+                data.pop_back();
+            }
+        }
+        std::vector<element_t> to_vector() const { return data; }
+    };
+
+    /** Stack-backed Λ(x) buffer for bare-metal / no-heap BM. */
+    struct BmStackPoly {
+        std::array<element_t, k_rs_bm_poly_cap> data{};
+        size_t coeff_len = 1;
+
+        BmStackPoly() { data[0] = 1; }
+
+        size_t len() const { return coeff_len; }
+        element_t at(size_t i) const { return data[i]; }
+        void ensure_len(size_t n)
+        {
+            if (n > k_rs_bm_poly_cap) {
+                throw std::length_error("rs_find_error_locator_noheap: polynomial capacity exceeded");
+            }
+            while (coeff_len < n) {
+                data[coeff_len++] = 0;
+            }
+        }
+        void add_at(size_t i, element_t v) { data[i] = static_cast<element_t>(data[i] ^ v); }
+        void copy_from(const BmStackPoly& o)
+        {
+            const size_t prev = coeff_len;
+            for (size_t i = 0; i < o.coeff_len; ++i) {
+                data[i] = o.data[i];
+            }
+            for (size_t i = o.coeff_len; i < prev; ++i) {
+                data[i] = 0;
+            }
+            coeff_len = o.coeff_len;
+        }
+        void trim()
+        {
+            while (coeff_len > 1 && data[coeff_len - 1] == 0) {
+                --coeff_len;
+            }
+        }
+        std::vector<element_t> to_vector() const
+        {
+            return std::vector<element_t>(data.begin(),
+                                          data.begin() + static_cast<std::ptrdiff_t>(coeff_len));
+        }
+    };
+
+    /**
+     * Shared Berlekamp–Massey locator step (heap and stack buffers use the same logic).
+     * Consumes syndromes[0..nsym-1] from rs_calc_syndromes.
+     */
+    template <typename BmPoly>
+    void rs_bm_locator_loop(const std::vector<element_t>& syndromes, uint8_t nsym, BmPoly& C,
+                            BmPoly& B) const
+    {
+        size_t L = 0;
+        element_t b_prev = 1;
+        size_t shift = 1;
+
+        for (uint8_t n = 0; n < nsym; ++n) {
+            element_t d = syndromes[n];
+            for (size_t i = 1; i <= L; ++i) {
+                if (i < C.len() && n >= i) {
+                    d = add(d, multiply(C.at(i), syndromes[n - i]));
+                }
+            }
+
+            if (d == 0) {
+                shift++;
+            } else {
+                BmPoly T;
+                T.copy_from(C);
+                const element_t coeff = divide(d, b_prev);
+                T.ensure_len(B.len() + shift);
+                for (size_t i = 0; i < B.len(); ++i) {
+                    T.add_at(i + shift, multiply(coeff, B.at(i)));
+                }
+
+                if (2 * L <= n) {
+                    L = n + 1 - L;
+                    B.copy_from(C);
+                    b_prev = d;
+                    shift = 1;
+                } else {
+                    shift++;
+                }
+                C.copy_from(T);
+            }
+        }
+        C.trim();
+    }
+
+    /** Ω(x) = S(x)·Λ(x) mod x^nsym with S_i = syndromes[i]. */
+    std::vector<element_t> rs_bm_compute_omega(const std::vector<element_t>& locator,
+                                                 const std::vector<element_t>& syndromes,
+                                                 uint8_t nsym) const
+    {
+        std::vector<element_t> omega(nsym, 0);
+        for (size_t i = 0; i < nsym; ++i) {
+            for (size_t j = 0; j < locator.size() && j <= i; ++j) {
+                omega[i] = add(omega[i], multiply(locator[j], syndromes[i - j]));
+            }
+        }
+        return omega;
+    }
 
     std::array<element_t, static_cast<size_t>(field_size)> exp_table;  // α^i lookup
     std::array<element_t, static_cast<size_t>(field_size)> log_table;  // log_α(i) lookup

--- a/test/neural/galois_field_bm_noheap_parity_test.cpp
+++ b/test/neural/galois_field_bm_noheap_parity_test.cpp
@@ -53,8 +53,7 @@ static bool test_random_syndromes(GF256& gf, uint8_t nsym, int trials, std::mt19
     std::uniform_int_distribution<int> dist(0, 255);
     for (int t = 0; t < trials; ++t) {
         std::vector<uint8_t> synd(static_cast<size_t>(nsym) + 1, 0);
-        synd[0] = 0;
-        for (uint8_t i = 1; i <= nsym; ++i) {
+        for (uint8_t i = 0; i < nsym; ++i) {
             synd[i] = static_cast<uint8_t>(dist(rng));
         }
         auto heap = gf.rs_find_error_locator(synd, nsym);
@@ -124,14 +123,8 @@ static bool round_trip_decode(std::mt19937& rng, int trials, const char* label)
             codew[i] = enc[i];
         }
 
-        // Random error count. RS(8,16) on short codewords (e.g. uint8_t → 17 symbols): BM path
-        // is validated through k<=3 in random XOR trials; k>=4 can fail (trial 0 k=4 reproduces).
-        unsigned k_cap;
-        if constexpr (Ecc >= 16) {
-            k_cap = 3u;
-        } else {
-            k_cap = static_cast<unsigned>(std::clamp(static_cast<int>(t), 1, 4));
-        }
+        // Random error count up to rated t (BM uses syndromes[0..nsym-1] from rs_calc_syndromes).
+        const unsigned k_cap = static_cast<unsigned>(std::clamp(static_cast<int>(t), 1, 8));
         const int k = static_cast<int>(rng() % k_cap);
         std::set<size_t> used;
         for (int e = 0; e < k; ++e) {
@@ -163,8 +156,7 @@ static bool round_trip_exactly_t_errors(const char* label)
         return true;
     }
 
-    const size_t n_err = (Ecc >= 16) ? (std::min(t - 1, static_cast<size_t>(3)))
-                                     : ((t >= 4) ? (t - 1) : t);
+    const size_t n_err = (t >= 4) ? (t - 1) : t;
     if (n_err == 0) {
         return true;
     }
@@ -244,11 +236,11 @@ int main()
     if (!round_trip_decode<uint8_t, 16>(rng, 1500, "uint8_t RS(8,16)")) {
         return 1;
     }
-    std::cout << "OK decode round-trip RS(8,16) (random k in 0..2)\n";
+    std::cout << "OK decode round-trip RS(8,16) (random k <= t)\n";
     if (!round_trip_exactly_t_errors<uint8_t, 16>("uint8_t RS(8,16)")) {
         return 1;
     }
-    std::cout << "OK decode RS(8,16) tail stress (<=3 tail flips; short-codecap)\n";
+    std::cout << "OK decode RS(8,16) tail stress (t-1 tail flips)\n";
 
     if (!round_trip_decode<uint32_t, 8>(rng, 2000, "uint32_t RS(8,8)")) {
         return 1;

--- a/test/neural/syndrome_index_probe.cpp
+++ b/test/neural/syndrome_index_probe.cpp
@@ -1,9 +1,20 @@
 /**
- * One-off probe: syndrome indexing + RS(8,16) k=4 decode
+ * @file syndrome_index_probe.cpp
+ * @brief Configurable RS syndrome / BM decode probe (manual diagnostic, not CTest)
+ *
+ * Usage:
+ *   syndrome_index_probe [--trials N] [--errors K] [--seed N] [--value V]
+ *                        [--ecc 4|6|8|16] [--fixed pos:mask,...] [--help]
  */
+
+#include <cstdint>
+#include <cstdlib>
 #include <iostream>
+#include <stdexcept>
 #include <random>
 #include <set>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include "../../include/rad_ml/neural/advanced_reed_solomon.hpp"
@@ -12,38 +23,139 @@
 using rad_ml::neural::AdvancedReedSolomon;
 using rad_ml::neural::GF256;
 
-int main()
+struct ProbeConfig {
+    int trials = 50;
+    int error_count = 4;
+    unsigned seed = 42;
+    uint8_t value = 0x42;
+    uint8_t ecc = 16;
+    std::vector<std::pair<size_t, uint8_t>> fixed_flips;
+    bool show_help = false;
+};
+
+static void print_usage(const char* prog)
 {
-    using RS = AdvancedReedSolomon<uint8_t, 8, 16>;
+    std::cout << "Usage: " << prog
+              << " [--trials N] [--errors K] [--seed N] [--value V]\n"
+                 "       [--ecc 4|6|8|16] [--fixed pos:mask,...] [--help]\n"
+                 "\n"
+                 "  --trials N     Random decode trials (default: 50)\n"
+                 "  --errors K     Symbol errors per random trial (default: 4)\n"
+                 "  --seed N       RNG seed (default: 42)\n"
+                 "  --value V      Data byte to encode (hex, default: 0x42)\n"
+                 "  --ecc N        ECC symbols: 4, 6, 8, or 16 (default: 16)\n"
+                 "  --fixed LIST   Fixed XOR pattern pos:mask,... for BM degree check\n"
+                 "                 (default: 0:0x11,3:0x22,7:0x33,12:0x44)\n";
+}
+
+static bool parse_hex_byte(const std::string& s, uint8_t& out)
+{
+    char* end = nullptr;
+    const unsigned long v = std::strtoul(s.c_str(), &end, 0);
+    if (end == s.c_str() || *end != '\0' || v > 0xFF) {
+        return false;
+    }
+    out = static_cast<uint8_t>(v);
+    return true;
+}
+
+static bool parse_fixed_list(const std::string& list, std::vector<std::pair<size_t, uint8_t>>& out)
+{
+    out.clear();
+    std::stringstream ss(list);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        const auto colon = item.find(':');
+        if (colon == std::string::npos) {
+            return false;
+        }
+        char* end = nullptr;
+        const unsigned long pos = std::strtoul(item.substr(0, colon).c_str(), &end, 0);
+        if (end == item.c_str() || pos > 255) {
+            return false;
+        }
+        uint8_t mask = 0;
+        if (!parse_hex_byte(item.substr(colon + 1), mask)) {
+            return false;
+        }
+        out.emplace_back(static_cast<size_t>(pos), mask);
+    }
+    return !out.empty();
+}
+
+static ProbeConfig parse_args(int argc, char** argv)
+{
+    ProbeConfig cfg;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            cfg.show_help = true;
+            return cfg;
+        }
+        auto need_value = [&](const char* name) -> std::string {
+            if (i + 1 >= argc) {
+                throw std::runtime_error(std::string("Missing value for ") + name);
+            }
+            return argv[++i];
+        };
+        if (arg == "--trials") {
+            cfg.trials = std::stoi(need_value("--trials"));
+        } else if (arg == "--errors") {
+            cfg.error_count = std::stoi(need_value("--errors"));
+        } else if (arg == "--seed") {
+            cfg.seed = static_cast<unsigned>(std::stoul(need_value("--seed")));
+        } else if (arg == "--value") {
+            if (!parse_hex_byte(need_value("--value"), cfg.value)) {
+                throw std::runtime_error("Invalid --value (use hex, e.g. 0x42)");
+            }
+        } else if (arg == "--ecc") {
+            cfg.ecc = static_cast<uint8_t>(std::stoul(need_value("--ecc")));
+        } else if (arg == "--fixed") {
+            if (!parse_fixed_list(need_value("--fixed"), cfg.fixed_flips)) {
+                throw std::runtime_error("Invalid --fixed (use pos:mask,pos:mask,...)");
+            }
+        } else {
+            throw std::runtime_error("Unknown argument: " + arg);
+        }
+    }
+    if (cfg.fixed_flips.empty()) {
+        cfg.fixed_flips = {{0, 0x11}, {3, 0x22}, {7, 0x33}, {12, 0x44}};
+    }
+    return cfg;
+}
+
+template <uint8_t Ecc>
+static int run_probe(const ProbeConfig& cfg)
+{
+    using RS = AdvancedReedSolomon<uint8_t, 8, Ecc>;
     RS rs;
     GF256 gf;
-    constexpr uint8_t nsym = 16;
+    constexpr uint8_t nsym = Ecc;
     constexpr size_t n_sym = RS::total_symbols;
 
-    const uint8_t original = 0x42;
-    std::vector<uint8_t> enc = rs.encode(original);
+    std::vector<uint8_t> enc = rs.encode(cfg.value);
     std::vector<uint8_t> codew(n_sym, 0);
     for (size_t i = 0; i < n_sym && i < enc.size(); ++i) {
         codew[i] = enc[i];
     }
 
     auto clean_synd = gf.rs_calc_syndromes(codew, nsym);
+    std::cout << "RS(8," << static_cast<int>(Ecc) << ") value=0x" << std::hex
+              << static_cast<int>(cfg.value) << std::dec << "\n";
     std::cout << "Clean codeword syndromes (size " << clean_synd.size() << "):\n  ";
     for (size_t i = 0; i < clean_synd.size(); ++i) {
         std::cout << "[" << i << "]=" << static_cast<int>(clean_synd[i]) << " ";
     }
     std::cout << "\n  index0_is_zero=" << (clean_synd[0] == 0 ? "yes" : "no")
-              << " (pad vs r(alpha^0))\n";
+              << " (on valid codeword, r(alpha^0)=0)\n";
 
-    std::mt19937 rng(42);
+    std::mt19937 rng(cfg.seed);
     std::uniform_int_distribution<int> err_mag(1, 255);
     int pass = 0;
-    constexpr int trials = 50;
-    for (int tr = 0; tr < trials; ++tr) {
+    for (int tr = 0; tr < cfg.trials; ++tr) {
         std::vector<uint8_t> corrupted = codew;
         std::set<size_t> used;
-        constexpr int k = 4;
-        for (int e = 0; e < k; ++e) {
+        for (int e = 0; e < cfg.error_count; ++e) {
             size_t pos = rng() % n_sym;
             while (!used.insert(pos).second) {
                 pos = (pos + 1) % n_sym;
@@ -52,37 +164,76 @@ int main()
                                                   static_cast<uint8_t>(err_mag(rng)));
         }
         auto dec = rs.decode(corrupted);
-        if (dec.has_value() && *dec == original) {
+        if (dec.has_value() && *dec == cfg.value) {
             ++pass;
         }
     }
-    std::cout << "RS(8,16) k=4 decode: " << pass << "/" << trials << " passed\n";
+    std::cout << "Random decode k=" << cfg.error_count << ": " << pass << "/" << cfg.trials
+              << " passed (seed=" << cfg.seed << ")\n";
 
-    // BM with shifted vs direct syndromes on first corrupted trial
     std::vector<uint8_t> corrupted = codew;
-    corrupted[0] ^= 0x11;
-    corrupted[3] ^= 0x22;
-    corrupted[7] ^= 0x33;
-    corrupted[12] ^= 0x44;
+    for (const auto& [pos, mask] : cfg.fixed_flips) {
+        if (pos < n_sym) {
+            corrupted[pos] = static_cast<uint8_t>(corrupted[pos] ^ mask);
+        }
+    }
     auto synd = gf.rs_calc_syndromes(corrupted, nsym);
 
     auto bm_direct = gf.rs_find_error_locator(synd, nsym);
     std::vector<uint8_t> padded(static_cast<size_t>(nsym) + 1, 0);
-    padded[0] = 0;
-    for (uint8_t i = 1; i <= nsym; ++i) {
-        padded[i] = synd[i];
+    for (uint8_t i = 0; i < nsym; ++i) {
+        padded[i + 1] = synd[i];
     }
     auto bm_padded = gf.rs_find_error_locator(padded, nsym);
 
     const auto& loc_direct = std::get<0>(bm_direct);
     const auto& loc_padded = std::get<0>(bm_padded);
-    std::cout << "BM locator degree (direct syndromes): " << (loc_direct.empty() ? 0 : loc_direct.size() - 1)
-              << "\n";
-    std::cout << "BM locator degree (padded [0]=0, [1..nsym]=synd): "
+    std::cout << "BM locator degree (direct syndromes[0..nsym-1]): "
+              << (loc_direct.empty() ? 0 : loc_direct.size() - 1) << "\n";
+    std::cout << "BM locator degree (legacy padded [1..nsym]): "
               << (loc_padded.empty() ? 0 : loc_padded.size() - 1) << "\n";
 
-    auto dec4 = rs.decode(corrupted);
-    std::cout << "Fixed 4-error decode: " << (dec4.has_value() && *dec4 == original ? "PASS" : "FAIL")
-              << "\n";
-    return 0;
+    auto dec_fixed = rs.decode(corrupted);
+    const bool ok = dec_fixed.has_value() && *dec_fixed == cfg.value;
+    std::cout << "Fixed-pattern decode (" << cfg.fixed_flips.size() << " errors): "
+              << (ok ? "PASS" : "FAIL") << "\n";
+    return ok ? 0 : 1;
+}
+
+static int dispatch_probe(const ProbeConfig& cfg)
+{
+    switch (cfg.ecc) {
+        case 4:
+            return run_probe<4>(cfg);
+        case 6:
+            return run_probe<6>(cfg);
+        case 8:
+            return run_probe<8>(cfg);
+        case 16:
+            return run_probe<16>(cfg);
+        default:
+            std::cerr << "Unsupported --ecc " << static_cast<int>(cfg.ecc)
+                      << " (use 4, 6, 8, or 16)\n";
+            return 1;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    try {
+        const ProbeConfig cfg = parse_args(argc, argv);
+        if (cfg.show_help) {
+            print_usage(argv[0]);
+            return 0;
+        }
+        if (cfg.trials < 0 || cfg.error_count < 0) {
+            std::cerr << "--trials and --errors must be non-negative\n";
+            return 1;
+        }
+        return dispatch_probe(cfg);
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
+        print_usage(argv[0]);
+        return 1;
+    }
 }

--- a/test/neural/syndrome_index_probe.cpp
+++ b/test/neural/syndrome_index_probe.cpp
@@ -1,0 +1,88 @@
+/**
+ * One-off probe: syndrome indexing + RS(8,16) k=4 decode
+ */
+#include <iostream>
+#include <random>
+#include <set>
+#include <vector>
+
+#include "../../include/rad_ml/neural/advanced_reed_solomon.hpp"
+#include "../../include/rad_ml/neural/galois_field.hpp"
+
+using rad_ml::neural::AdvancedReedSolomon;
+using rad_ml::neural::GF256;
+
+int main()
+{
+    using RS = AdvancedReedSolomon<uint8_t, 8, 16>;
+    RS rs;
+    GF256 gf;
+    constexpr uint8_t nsym = 16;
+    constexpr size_t n_sym = RS::total_symbols;
+
+    const uint8_t original = 0x42;
+    std::vector<uint8_t> enc = rs.encode(original);
+    std::vector<uint8_t> codew(n_sym, 0);
+    for (size_t i = 0; i < n_sym && i < enc.size(); ++i) {
+        codew[i] = enc[i];
+    }
+
+    auto clean_synd = gf.rs_calc_syndromes(codew, nsym);
+    std::cout << "Clean codeword syndromes (size " << clean_synd.size() << "):\n  ";
+    for (size_t i = 0; i < clean_synd.size(); ++i) {
+        std::cout << "[" << i << "]=" << static_cast<int>(clean_synd[i]) << " ";
+    }
+    std::cout << "\n  index0_is_zero=" << (clean_synd[0] == 0 ? "yes" : "no")
+              << " (pad vs r(alpha^0))\n";
+
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<int> err_mag(1, 255);
+    int pass = 0;
+    constexpr int trials = 50;
+    for (int tr = 0; tr < trials; ++tr) {
+        std::vector<uint8_t> corrupted = codew;
+        std::set<size_t> used;
+        constexpr int k = 4;
+        for (int e = 0; e < k; ++e) {
+            size_t pos = rng() % n_sym;
+            while (!used.insert(pos).second) {
+                pos = (pos + 1) % n_sym;
+            }
+            corrupted[pos] = static_cast<uint8_t>(corrupted[pos] ^
+                                                  static_cast<uint8_t>(err_mag(rng)));
+        }
+        auto dec = rs.decode(corrupted);
+        if (dec.has_value() && *dec == original) {
+            ++pass;
+        }
+    }
+    std::cout << "RS(8,16) k=4 decode: " << pass << "/" << trials << " passed\n";
+
+    // BM with shifted vs direct syndromes on first corrupted trial
+    std::vector<uint8_t> corrupted = codew;
+    corrupted[0] ^= 0x11;
+    corrupted[3] ^= 0x22;
+    corrupted[7] ^= 0x33;
+    corrupted[12] ^= 0x44;
+    auto synd = gf.rs_calc_syndromes(corrupted, nsym);
+
+    auto bm_direct = gf.rs_find_error_locator(synd, nsym);
+    std::vector<uint8_t> padded(static_cast<size_t>(nsym) + 1, 0);
+    padded[0] = 0;
+    for (uint8_t i = 1; i <= nsym; ++i) {
+        padded[i] = synd[i];
+    }
+    auto bm_padded = gf.rs_find_error_locator(padded, nsym);
+
+    const auto& loc_direct = std::get<0>(bm_direct);
+    const auto& loc_padded = std::get<0>(bm_padded);
+    std::cout << "BM locator degree (direct syndromes): " << (loc_direct.empty() ? 0 : loc_direct.size() - 1)
+              << "\n";
+    std::cout << "BM locator degree (padded [0]=0, [1..nsym]=synd): "
+              << (loc_padded.empty() ? 0 : loc_padded.size() - 1) << "\n";
+
+    auto dec4 = rs.decode(corrupted);
+    std::cout << "Fixed 4-error decode: " << (dec4.has_value() && *dec4 == original ? "PASS" : "FAIL")
+              << "\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary by Sourcery

Align Reed–Solomon Berlekamp–Massey decoding with zero-based syndromes and validate full designed error-correction capability, including a new diagnostic probe for RS(8,16).

Bug Fixes:
- Correct Berlekamp–Massey discrepancy and error-evaluator computations to use syndromes[0..nsym-1] instead of shifted indices, fixing RS decoding for higher error counts.

Enhancements:
- Relax RS(8,16) test harness to exercise random error patterns up to the rated correction capability and simplify exact-t error stress logic.
- Clarify documentation comments around syndrome polynomial definition and indexing in the Galois field implementation.

Build:
- Add a standalone syndrome_index_probe executable to CMake for manual RS(8,16) syndrome and k=4 decode diagnostics.

Tests:
- Update BM parity and round-trip tests to generate and consume zero-based syndromes and to cover stronger RS(8,16) error patterns.