### PR TITLE
TMR voting now uses the CRC checksums the framework was already storing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,15 +38,18 @@ else()
 endif()
 
 # Set optimized compiler flags
+# NOTE: -ffast-math is deliberately NOT used. It implies -ffinite-math-only,
+# which breaks std::isnan/NaN propagation and silently disables the IEEE-754
+# NaN/Inf-aware TMR voting (ieee754_tmr_test fails under -ffast-math).
 if(ENABLE_OPTIMIZATIONS)
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -march=native -flto -DNDEBUG -ffast-math")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -march=native -flto -DNDEBUG -ffast-math")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -march=native -flto -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -march=native -flto -DNDEBUG")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1 -g -DDEBUG")
   endif()
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvectorize -fslp-vectorize -ffast-math -funroll-loops")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvectorize -fslp-vectorize -funroll-loops")
   endif()
 endif()
 
@@ -407,6 +410,27 @@ add_test(NAME galois_field_bm_noheap_parity_test COMMAND galois_field_bm_noheap_
 add_executable(hamming_secded_test test/neural/hamming_secded_test.cpp)
 target_include_directories(hamming_secded_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
 add_test(NAME hamming_secded_test COMMAND hamming_secded_test)
+
+# Protection lifecycle regression test for UnifiedMemoryManager
+# (allocate -> corrupt -> verify -> deallocate for CANARY/CRC/ECC/TMR)
+add_executable(unified_memory_test test/unit/core/memory/unified_memory_test.cpp)
+target_include_directories(unified_memory_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(unified_memory_test PRIVATE Threads::Threads)
+add_test(NAME unified_memory_test COMMAND unified_memory_test)
+
+# Checksum-assisted adaptive voting regression test
+# (EnhancedVoting::adaptiveVote with write-time CRC + EnhancedTMR CRC-assisted selection)
+add_executable(checksum_voting_test test/unit/core/redundancy/checksum_voting_test.cpp)
+target_include_directories(checksum_voting_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(checksum_voting_test PRIVATE Threads::Threads)
+add_test(NAME checksum_voting_test COMMAND checksum_voting_test)
+
+# Bit-exact semantics regression test for SystematicFaultInjector::injectFault
+add_executable(fault_injection_bits_test
+    test/unit/testing/fault_injection_bits_test.cpp
+    src/testing/fault_injection.cpp)
+target_include_directories(fault_injection_bits_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+add_test(NAME fault_injection_bits_test COMMAND fault_injection_bits_test)
 
 # Verbose RS systematic-encoding diagnostic (manual inspection; not a strict regression test)
 add_executable(reed_solomon_fixed_diagnostic test/neural/reed_solomon_fixed_diagnostic.cpp)

--- a/include/rad_ml/api/rad_ml.hpp
+++ b/include/rad_ml/api/rad_ml.hpp
@@ -423,25 +423,50 @@ inline error::Result<T> makeError(error::ErrorCode code, error::ErrorCategory ca
  */
 namespace neural {
 /**
+ * @brief A neural network paired with its selective-hardening engine
+ *
+ * SelectiveHardening does not wrap the network transparently: the caller
+ * describes the network's components (weights, biases, ...) as
+ * neural::NetworkComponent entries, runs hardening->analyzeAndProtect(...) once,
+ * and then protects/verifies individual values with hardening->applyProtection(...)
+ * using the returned analysis.
+ *
+ * @tparam Network Neural network type
+ */
+template <typename Network>
+struct ProtectedNetwork {
+    std::unique_ptr<Network> network;                       ///< The network being protected
+    std::unique_ptr<neural::SelectiveHardening> hardening;  ///< Hardening engine
+    neural::ProtectionLevel requested_level;                ///< Protection level requested at creation
+};
+
+/**
  * @brief Create a neural network with selective hardening
+ *
+ * The hardening engine is configured with the given strategy. The requested
+ * protection level is recorded on the returned pair; the effective per-component
+ * levels are decided by the strategy when analyzeAndProtect() is run.
  *
  * @tparam Network Neural network type
  * @tparam Args Constructor argument types (these are forwarded to the network's constructor)
  * @param strategy Hardening strategy
- * @param protection_level Protection level
+ * @param protection_level Requested protection level
  * @param args Arguments forwarded to the network constructor (e.g., layer sizes, input/output dims,
  * etc.)
- * @return Protected neural network instance
+ * @return The network together with its configured hardening engine
  */
 template <typename Network, typename... Args>
-inline std::unique_ptr<neural::SelectiveHardening> createProtectedNetwork(
+inline ProtectedNetwork<Network> createProtectedNetwork(
     neural::HardeningStrategy strategy, neural::ProtectionLevel protection_level, Args&&... args)
 {
-    auto network = std::make_unique<Network>(std::forward<Args>(args)...);
-    auto protected_network =
-        std::make_unique<neural::SelectiveHardening>(neural::HardeningConfig::defaultConfig());
+    auto config = neural::HardeningConfig::defaultConfig();
+    config.strategy = strategy;
 
-    return protected_network;
+    ProtectedNetwork<Network> result;
+    result.network = std::make_unique<Network>(std::forward<Args>(args)...);
+    result.hardening = std::make_unique<neural::SelectiveHardening>(config);
+    result.requested_level = protection_level;
+    return result;
 }
 
 /**
@@ -476,10 +501,11 @@ namespace simulation {
  * @return Radiation simulator instance
  */
 inline std::unique_ptr<sim::PhysicsRadiationSimulator> createRadiationSimulator(
-    sim::RadiationEnvironment environment = sim::RadiationEnvironment::EARTH_ORBIT,
+    sim::SpaceEnvironment environment = sim::SpaceEnvironment::EARTH_ORBIT,
     double intensity = 0.5)
 {
-    auto simulator = std::make_unique<sim::PhysicsRadiationSimulator>(environment);
+    auto simulator =
+        std::make_unique<sim::PhysicsRadiationSimulator>(sim::EnvironmentParams(environment));
     simulator->setIntensity(intensity);
 
     return simulator;

--- a/include/rad_ml/core/memory/unified_memory.hpp
+++ b/include/rad_ml/core/memory/unified_memory.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -18,8 +19,10 @@
 namespace rad_ml {
 namespace memory {
 
-// Canary value for memory protection
-constexpr uint32_t CANARY_VALUE = 0xDEADBEEF;
+// Canary value for memory protection (read/written via std::memcpy because the
+// trailing canary is not guaranteed to be aligned for uint64_t access)
+using CanaryType = std::uint64_t;
+constexpr CanaryType CANARY_VALUE = 0xDEADBEEFDEADBEEFULL;
 
 /**
  * @brief Memory protection level
@@ -184,11 +187,10 @@ class UnifiedMemoryManager {
     {
         std::lock_guard<std::mutex> lock(mutex_);
 
-        // Adjust size for protection if needed
-        size_t adjusted_size = size;
-        if (protection_level != MemoryProtectionLevel::NONE) {
-            adjusted_size = calculateProtectedSize(size, protection_level);
-        }
+        // Extra space required before/after the user region for this protection level
+        const size_t header = protectionHeaderSize(protection_level, flags, alignment);
+        const size_t trailer = protectionTrailerSize(protection_level, size);
+        const size_t adjusted_size = header + size + trailer;
 
         // Perform allocation
         void* allocated_ptr = nullptr;
@@ -216,34 +218,28 @@ class UnifiedMemoryManager {
                 std::memset(allocated_ptr, 0, adjusted_size);
             }
 
-            // Set the return pointer based on protection level
-            return_ptr = allocated_ptr;
+            // The user-facing pointer is offset past any protection header
+            return_ptr = static_cast<uint8_t*>(allocated_ptr) + header;
 
-            // Adjust return pointer based on protection scheme
-            if (protection_level == MemoryProtectionLevel::CANARY) {
-                // Skip the first canary value
-                return_ptr = static_cast<uint8_t*>(allocated_ptr) + sizeof(uint64_t);
-            }
+            // Track by the user-facing pointer, since that is what callers hand
+            // back to deallocate()/verifyMemoryIntegrity()
+            MemoryAllocationInfo& info = trackAllocation(return_ptr, allocated_ptr, size, location);
+            info.protection_level = protection_level;
 
-            // Setup protection if needed
-            if (protection_level != MemoryProtectionLevel::NONE) {
-                setupMemoryProtection(allocated_ptr, adjusted_size, protection_level);
-            }
-
-            // Track allocation - store the allocated pointer, but return the adjusted one
-            trackAllocation(allocated_ptr, size, location);
-
-            // Update allocation info to include both pointers
-            auto it = allocations_.find(allocated_ptr);
-            if (it != allocations_.end()) {
-                it->second.ptr = return_ptr;              // User-facing pointer
-                it->second.original_ptr = allocated_ptr;  // Original allocation pointer
+            if (isConcreteProtection(protection_level)) {
+                setupProtectionLocked(info);
+                info.is_protected.store(true);
+                stats_.protected_allocations++;
+                stats_.protected_bytes += size;
             }
 
             return return_ptr;
         }
         catch (const std::exception& e) {
             if (allocated_ptr) {
+                if (return_ptr) {
+                    allocations_.erase(return_ptr);
+                }
                 std::free(allocated_ptr);
             }
 
@@ -347,9 +343,7 @@ class UnifiedMemoryManager {
 
         // Check for corruption before freeing
         if (it->second.is_protected.load()) {
-            if (!verifyMemoryIntegrity(ptr)) {
-                stats_.detected_corruption++;
-
+            if (!verifyIntegrityLocked(it->second)) {
                 error::ErrorHandler::logError(error::ErrorInfo(
                     error::ErrorCode::MEMORY_CORRUPTION_DETECTED, error::ErrorCategory::MEMORY,
                     error::ErrorSeverity::ERROR, "Memory corruption detected during deallocation",
@@ -357,7 +351,7 @@ class UnifiedMemoryManager {
                     "Address: " + std::to_string(reinterpret_cast<uintptr_t>(ptr))));
 
                 // Attempt to repair if possible
-                if (tryRepairMemory(ptr)) {
+                if (tryRepairMemoryLocked(it->second)) {
                     stats_.repaired_corruption++;
                 }
             }
@@ -373,11 +367,14 @@ class UnifiedMemoryManager {
             stats_.protected_bytes -= it->second.size;
         }
 
+        // Free the underlying allocation (may differ from the user-facing
+        // pointer when a protection header precedes the user region)
+        void* original_ptr = it->second.original_ptr;
+
         // Remove from tracking
         allocations_.erase(it);
 
-        // Free the memory
-        std::free(ptr);
+        std::free(original_ptr);
 
         return true;
     }
@@ -504,20 +501,36 @@ class UnifiedMemoryManager {
             return false;
         }
 
-        // If already protected, remove old protection first
-        if (it->second.is_protected.load()) {
-            removeMemoryProtection(ptr);
+        MemoryAllocationInfo& info = it->second;
+
+        // Protection metadata space (canaries, CRC, parity bits, TMR copies) is
+        // reserved at allocation time. Applying a different concrete protection
+        // level after the fact would write past the allocation, so it is
+        // rejected instead of corrupting the heap.
+        if (isConcreteProtection(level) && level != info.protection_level) {
+            error::ErrorHandler::logError(error::ErrorInfo(
+                error::ErrorCode::MEMORY_ACCESS_VIOLATION, error::ErrorCategory::MEMORY,
+                error::ErrorSeverity::ERROR,
+                "Cannot change protection level after allocation; allocate with the desired level",
+                error::SourceLocation(__FILE__, __LINE__, __func__),
+                "Address: " + std::to_string(reinterpret_cast<uintptr_t>(ptr))));
+            return false;
         }
 
-        // Setup protection
-        if (setupMemoryProtection(ptr, it->second.size, level)) {
-            it->second.is_protected.store(true);
+        if (!isConcreteProtection(level)) {
+            return false;
+        }
+
+        // Re-arm protection (refresh canaries/CRC/parity/TMR copies from the
+        // current contents of the user region)
+        setupProtectionLocked(info);
+
+        if (!info.is_protected.load()) {
+            info.is_protected.store(true);
             stats_.protected_allocations++;
-            stats_.protected_bytes += it->second.size;
-            return true;
+            stats_.protected_bytes += info.size;
         }
-
-        return false;
+        return true;
     }
 
     /**
@@ -539,14 +552,11 @@ class UnifiedMemoryManager {
             return true;  // Already unprotected
         }
 
-        if (removeMemoryProtection(ptr)) {
-            it->second.is_protected.store(false);
-            stats_.protected_allocations--;
-            stats_.protected_bytes -= it->second.size;
-            return true;
-        }
-
-        return false;
+        // Protection metadata is left in place; it is simply no longer checked.
+        it->second.is_protected.store(false);
+        stats_.protected_allocations--;
+        stats_.protected_bytes -= it->second.size;
+        return true;
     }
 
     /**
@@ -559,95 +569,13 @@ class UnifiedMemoryManager {
     {
         std::lock_guard<std::mutex> lock(mutex_);
 
-        // Find allocation info
-        auto it = std::find_if(allocations_.begin(), allocations_.end(),
-                               [ptr](const auto& pair) { return pair.second.ptr == ptr; });
-
+        auto it = allocations_.find(ptr);
         if (it == allocations_.end()) {
             // Not found - not our memory
             return false;
         }
 
-        // Use original_ptr for verification since that's where protection is applied
-        void* mem_ptr = it->second.original_ptr;
-        size_t size = it->second.size;
-
-        // Get the protection level for this allocation
-        auto protection_level = getDefaultProtectionLevel();
-
-        // Verify based on protection type
-        switch (protection_level) {
-            case MemoryProtectionLevel::CANARY: {
-                // Check canary values at beginning and end
-                uint64_t* start_canary = reinterpret_cast<uint64_t*>(mem_ptr);
-                uint64_t* end_canary = reinterpret_cast<uint64_t*>(
-                    reinterpret_cast<uint8_t*>(mem_ptr) + size + sizeof(uint64_t));
-
-                bool start_valid = (*start_canary == CANARY_VALUE);
-                bool end_valid = (*end_canary == CANARY_VALUE);
-
-                if (!start_valid || !end_valid) {
-                    stats_.detected_corruption++;
-
-                    // Report memory corruption
-                    for (const auto& [id, callback] : corruption_callbacks_) {
-                        callback(ptr, size, "Memory corruption detected: canary value modified");
-                    }
-
-                    return false;
-                }
-                return true;
-            }
-
-            case MemoryProtectionLevel::CRC: {
-                // Calculate CRC for the memory block
-                uint32_t crc = calculateCRC32(static_cast<const uint8_t*>(mem_ptr), size);
-
-                // Store the CRC in the metadata
-                auto it = allocations_.find(mem_ptr);
-                if (it != allocations_.end()) {
-                    it->second.is_protected = true;
-                    // In a real implementation, we would store the CRC somewhere
-                    // For now, we'll just set the protected flag
-                }
-                return true;
-            }
-
-            case MemoryProtectionLevel::ECC: {
-                // Simplified ECC check
-                // In a real implementation, this would use proper ECC algorithms
-                // such as Hamming code or Reed-Solomon
-                uint8_t* ecc_data = static_cast<uint8_t*>(mem_ptr) + size;
-                bool is_valid = verifyECC(static_cast<uint8_t*>(mem_ptr), size, ecc_data);
-                return is_valid;
-            }
-
-            case MemoryProtectionLevel::TMR: {
-                // Triple Modular Redundancy - compare three copies
-                size_t chunk_size = size;
-                uint8_t* copy1 = static_cast<uint8_t*>(mem_ptr);
-                uint8_t* copy2 = static_cast<uint8_t*>(mem_ptr) + chunk_size;
-                uint8_t* copy3 = static_cast<uint8_t*>(mem_ptr) + 2 * chunk_size;
-
-                // Compare byte by byte
-                for (size_t i = 0; i < chunk_size; ++i) {
-                    // Majority voting
-                    int correct_value = majorityVote(copy1[i], copy2[i], copy3[i]);
-
-                    // If any copy is corrupt, the memory is corrupt
-                    if (copy1[i] != correct_value || copy2[i] != correct_value ||
-                        copy3[i] != correct_value) {
-                        stats_.detected_corruption++;
-                        return false;
-                    }
-                }
-                return true;
-            }
-
-            default:
-                // No additional checks for unknown protection types
-                return true;
-        }
+        return verifyIntegrityLocked(it->second);
     }
 
     /**
@@ -713,15 +641,20 @@ class UnifiedMemoryManager {
     UnifiedMemoryManager& operator=(UnifiedMemoryManager&&) = delete;
 
     /**
-     * @brief Track a new allocation
+     * @brief Track a new allocation (caller must hold mutex_)
      *
-     * @param ptr Memory pointer
-     * @param size Size in bytes
+     * @param user_ptr User-facing pointer (map key)
+     * @param original_ptr Pointer returned by malloc/aligned_alloc
+     * @param size User-visible size in bytes
      * @param location Source location
+     * @return Reference to the new tracking entry
      */
-    void trackAllocation(void* ptr, size_t size, const std::string& location)
+    MemoryAllocationInfo& trackAllocation(void* user_ptr, void* original_ptr, size_t size,
+                                          const std::string& location)
     {
-        allocations_.emplace(ptr, MemoryAllocationInfo(ptr, size, location));
+        auto result = allocations_.emplace(user_ptr, MemoryAllocationInfo(user_ptr, size, location));
+        MemoryAllocationInfo& info = result.first->second;
+        info.original_ptr = original_ptr;
 
         // Update stats
         stats_.current_allocations++;
@@ -735,261 +668,251 @@ class UnifiedMemoryManager {
         if (stats_.current_bytes > stats_.peak_bytes) {
             stats_.peak_bytes = stats_.current_bytes;
         }
+
+        return info;
     }
 
     /**
-     * @brief Calculate size needed for protected allocation
+     * @brief Whether a protection level has a concrete in-memory scheme
      *
-     * @param original_size Original size
-     * @param level Protection level
-     * @return Adjusted size
+     * The abstract levels (MINIMAL..ADAPTIVE) are policy hints with no
+     * metadata layout of their own.
      */
-    size_t calculateProtectedSize(size_t original_size, MemoryProtectionLevel level)
+    static bool isConcreteProtection(MemoryProtectionLevel level)
     {
         switch (level) {
-            case MemoryProtectionLevel::NONE:
-                return original_size;
-
             case MemoryProtectionLevel::CANARY:
-                // Need space for canary values at start and end
-                return original_size + 2 * sizeof(uint64_t);
-
             case MemoryProtectionLevel::CRC:
-                // Need space for the CRC value
-                return original_size + sizeof(uint32_t);
-
             case MemoryProtectionLevel::ECC:
-                // ECC typically requires ~12.5% overhead (simplified for demonstration)
-                return original_size + (original_size / 8);
-
             case MemoryProtectionLevel::TMR:
-                // Triple the size for TMR
-                return original_size * 3;
-
+                return true;
             default:
-                return original_size;
+                return false;
         }
     }
 
     /**
-     * @brief Setup memory protection for an allocation
+     * @brief Bytes reserved before the user region for this protection level
      *
-     * @param ptr Memory pointer
-     * @param size Size in bytes
-     * @param level Protection level
-     * @return True if protection was set up successfully
+     * Only CANARY uses a header (the leading canary). The header is padded so
+     * the user pointer keeps the alignment guarantee of the allocator.
      */
-    bool setupMemoryProtection(void* ptr, size_t size, MemoryProtectionLevel level)
+    static size_t protectionHeaderSize(MemoryProtectionLevel level, MemoryFlags flags,
+                                       size_t alignment)
     {
-        if (!ptr) {
-            return false;
+        if (level != MemoryProtectionLevel::CANARY) {
+            return 0;
         }
 
-        switch (level) {
-            case MemoryProtectionLevel::CANARY: {
-                // Add canary values at beginning and end of allocation
-                // Fix: Properly place canaries by adjusting the returned pointer
-                uint64_t* memory_start = reinterpret_cast<uint64_t*>(ptr);
-                uint64_t* memory_end = reinterpret_cast<uint64_t*>(reinterpret_cast<uint8_t*>(ptr) +
-                                                                   size - sizeof(uint64_t));
+        const size_t min_header =
+            (flags & MemoryFlags::ALIGNED) ? alignment : alignof(std::max_align_t);
+        return ((sizeof(CanaryType) + min_header - 1) / min_header) * min_header;
+    }
 
-                // Set canary values
-                *memory_start = CANARY_VALUE;
-                *memory_end = CANARY_VALUE;
-                return true;
+    /**
+     * @brief Bytes reserved after the user region for this protection level
+     */
+    static size_t protectionTrailerSize(MemoryProtectionLevel level, size_t size)
+    {
+        switch (level) {
+            case MemoryProtectionLevel::CANARY:
+                return sizeof(CanaryType);
+            case MemoryProtectionLevel::CRC:
+                return sizeof(uint32_t);
+            case MemoryProtectionLevel::ECC:
+                return (size + 7) / 8;  // 1 parity bit per byte
+            case MemoryProtectionLevel::TMR:
+                return 2 * size;  // Two extra copies
+            default:
+                return 0;
+        }
+    }
+
+    /**
+     * @brief Write protection metadata from the current user-region contents
+     * (caller must hold mutex_)
+     *
+     * Layout, relative to the user pointer P with user size S:
+     * - CANARY: canary at [P - 8, P) and [P + S, P + S + 8)
+     * - CRC:    stored CRC32 at [P + S, P + S + 4)
+     * - ECC:    parity bits at [P + S, P + S + ceil(S/8))
+     * - TMR:    copies at [P + S, P + 2S) and [P + 2S, P + 3S)
+     */
+    void setupProtectionLocked(MemoryAllocationInfo& info)
+    {
+        uint8_t* user = static_cast<uint8_t*>(info.ptr);
+        const size_t size = info.size;
+
+        switch (info.protection_level) {
+            case MemoryProtectionLevel::CANARY: {
+                std::memcpy(user - sizeof(CanaryType), &CANARY_VALUE, sizeof(CanaryType));
+                std::memcpy(user + size, &CANARY_VALUE, sizeof(CanaryType));
+                break;
             }
 
             case MemoryProtectionLevel::CRC: {
-                // Calculate CRC for the memory block
-                uint32_t crc = calculateCRC32(static_cast<const uint8_t*>(ptr), size);
-
-                // Store the CRC in the metadata
-                auto it = allocations_.find(ptr);
-                if (it != allocations_.end()) {
-                    it->second.is_protected = true;
-                    // In a real implementation, we would store the CRC somewhere
-                    // For now, we'll just set the protected flag
-                }
-                return true;
+                const uint32_t crc = calculateCRC32(user, size);
+                std::memcpy(user + size, &crc, sizeof(crc));
+                break;
             }
 
             case MemoryProtectionLevel::ECC: {
-                // Calculate and store ECC data
-                uint8_t* ecc_data = static_cast<uint8_t*>(ptr) + size;
-                size_t ecc_size = (size + 7) / 8;  // 1 bit per byte
+                uint8_t* ecc_data = user + size;
+                const size_t ecc_size = (size + 7) / 8;
 
-                // Clear ECC data area
                 std::memset(ecc_data, 0, ecc_size);
 
-                // Calculate and store parity bits
                 for (size_t i = 0; i < size; ++i) {
-                    uint8_t byte = static_cast<uint8_t*>(ptr)[i];
-                    uint8_t parity = 0;
-
-                    // Calculate parity
-                    for (int bit = 0; bit < 8; ++bit) {
-                        parity ^= ((byte >> bit) & 1);
-                    }
-
-                    // Store parity bit
-                    if (parity) {
+                    if (byteParity(user[i])) {
                         ecc_data[i / 8] |= (1 << (i % 8));
                     }
                 }
-                return true;
+                break;
             }
 
             case MemoryProtectionLevel::TMR: {
-                // Triplicate the data
-                size_t chunk_size = size;
-
-                // Make two additional copies
-                std::memcpy(static_cast<uint8_t*>(ptr) + chunk_size, ptr, chunk_size);
-                std::memcpy(static_cast<uint8_t*>(ptr) + 2 * chunk_size, ptr, chunk_size);
-                return true;
+                std::memcpy(user + size, user, size);
+                std::memcpy(user + 2 * size, user, size);
+                break;
             }
 
-            case MemoryProtectionLevel::NONE:
             default:
-                // No protection
+                break;
+        }
+    }
+
+    /**
+     * @brief Verify integrity of one allocation (caller must hold mutex_)
+     *
+     * Uses the protection level the allocation was created with. On failure,
+     * updates corruption stats and fires corruption callbacks. Callbacks are
+     * invoked while the lock is held and must not call back into the manager.
+     *
+     * @return True if memory is intact
+     */
+    bool verifyIntegrityLocked(MemoryAllocationInfo& info)
+    {
+        uint8_t* user = static_cast<uint8_t*>(info.ptr);
+        const size_t size = info.size;
+
+        bool intact = true;
+        std::string failure_reason;
+
+        switch (info.protection_level) {
+            case MemoryProtectionLevel::CANARY: {
+                CanaryType start_canary = 0;
+                CanaryType end_canary = 0;
+                std::memcpy(&start_canary, user - sizeof(CanaryType), sizeof(CanaryType));
+                std::memcpy(&end_canary, user + size, sizeof(CanaryType));
+
+                if (start_canary != CANARY_VALUE || end_canary != CANARY_VALUE) {
+                    intact = false;
+                    failure_reason = "canary value modified";
+                }
+                break;
+            }
+
+            case MemoryProtectionLevel::CRC: {
+                uint32_t stored_crc = 0;
+                std::memcpy(&stored_crc, user + size, sizeof(stored_crc));
+
+                if (calculateCRC32(user, size) != stored_crc) {
+                    intact = false;
+                    failure_reason = "CRC mismatch";
+                }
+                break;
+            }
+
+            case MemoryProtectionLevel::ECC: {
+                if (!verifyECC(user, size, user + size)) {
+                    intact = false;
+                    failure_reason = "parity mismatch";
+                }
+                break;
+            }
+
+            case MemoryProtectionLevel::TMR: {
+                const uint8_t* copy1 = user;
+                const uint8_t* copy2 = user + size;
+                const uint8_t* copy3 = user + 2 * size;
+
+                for (size_t i = 0; i < size; ++i) {
+                    if (copy1[i] != copy2[i] || copy1[i] != copy3[i]) {
+                        intact = false;
+                        failure_reason = "TMR copies disagree";
+                        break;
+                    }
+                }
+                break;
+            }
+
+            default:
+                // No concrete protection - nothing to check
                 return true;
         }
-    }
 
-    /**
-     * @brief Remove memory protection from an allocation
-     *
-     * @param ptr Memory pointer
-     * @return True if protection was removed successfully
-     */
-    bool removeMemoryProtection(void* ptr)
-    {
-        if (!ptr) {
-            return false;
-        }
+        if (!intact) {
+            stats_.detected_corruption++;
 
-        auto it = allocations_.find(ptr);
-        if (it == allocations_.end()) {
-            return false;
-        }
-
-        // If already unprotected, nothing to do
-        if (!it->second.is_protected.load()) {
-            return true;
-        }
-
-        // Update protection status
-        it->second.is_protected.store(false);
-
-        // Update statistics
-        stats_.protected_allocations--;
-        stats_.protected_bytes -= it->second.size;
-
-        // No need to clear the protection data as it will be overwritten
-        // by future allocations, and the space is already accounted for
-
-        return true;
-    }
-
-    /**
-     * @brief Try to repair corrupted memory
-     *
-     * @param ptr Memory pointer
-     * @return True if repair was successful
-     */
-    bool tryRepairMemory(void* ptr)
-    {
-        // Implementation of memory repair logic based on protection level
-        auto it = allocations_.find(ptr);
-        if (it == allocations_.end()) {
-            return false;
-        }
-
-        // Notify all callbacks
-        for (const auto& callback_pair : corruption_callbacks_) {
-            try {
-                callback_pair.second(ptr, it->second.size, it->second.type_name);
-            }
-            catch (...) {
-                // Ignore callback errors
+            for (const auto& [id, callback] : corruption_callbacks_) {
+                try {
+                    callback(info.ptr, size, "Memory corruption detected: " + failure_reason);
+                }
+                catch (...) {
+                    // Ignore callback errors
+                }
             }
         }
 
-        if (!it->second.is_protected.load()) {
+        return intact;
+    }
+
+    /**
+     * @brief Try to repair corrupted memory (caller must hold mutex_)
+     *
+     * @return True if a repair was performed
+     */
+    bool tryRepairMemoryLocked(MemoryAllocationInfo& info)
+    {
+        if (!info.is_protected.load()) {
             // Cannot repair unprotected memory
             return false;
         }
 
-        uint8_t* mem_ptr = static_cast<uint8_t*>(ptr);
-        size_t size = it->second.size;
+        uint8_t* user = static_cast<uint8_t*>(info.ptr);
+        const size_t size = info.size;
         bool repaired = false;
-        auto protection_level = getDefaultProtectionLevel();
 
-        switch (protection_level) {
-            case MemoryProtectionLevel::CANARY: {
-                // For canary, we can't actually repair the data,
-                // we can only detect the corruption
+        switch (info.protection_level) {
+            case MemoryProtectionLevel::CANARY:
+            case MemoryProtectionLevel::CRC:
+                // Detection-only schemes - cannot repair
                 return false;
-            }
-
-            case MemoryProtectionLevel::CRC: {
-                // For CRC, we can only detect, not repair
-                return false;
-            }
 
             case MemoryProtectionLevel::ECC: {
-                // For ECC, we can repair single-bit errors
-                uint8_t* ecc_data = mem_ptr + size;
+                // Parity can detect single-bit errors per byte but cannot
+                // locate the flipped bit; restoring parity by guessing a bit
+                // would corrupt data further, so only report.
+                uint8_t* ecc_data = user + size;
 
-                // Check each byte's parity and try to repair
                 for (size_t i = 0; i < size; ++i) {
-                    uint8_t parity = 0;
-                    uint8_t byte = mem_ptr[i];
-
-                    // Calculate parity
-                    for (int bit = 0; bit < 8; ++bit) {
-                        parity ^= ((byte >> bit) & 1);
-                    }
-
-                    // Compare with stored parity
-                    uint8_t stored_parity = (ecc_data[i / 8] >> (i % 8)) & 1;
-
-                    if (parity != stored_parity) {
-                        // Try to find the flipped bit
-                        for (int bit = 0; bit < 8; ++bit) {
-                            // Flip this bit and see if parity matches
-                            uint8_t test_byte = byte ^ (1 << bit);
-                            uint8_t test_parity = 0;
-
-                            for (int j = 0; j < 8; ++j) {
-                                test_parity ^= ((test_byte >> j) & 1);
-                            }
-
-                            if (test_parity == stored_parity) {
-                                // Found the likely bit flip, repair it
-                                mem_ptr[i] = test_byte;
-                                repaired = true;
-                                break;
-                            }
-                        }
+                    const uint8_t stored_parity = (ecc_data[i / 8] >> (i % 8)) & 1;
+                    if (byteParity(user[i]) != stored_parity) {
+                        return false;  // Corruption present but not repairable
                     }
                 }
-                return repaired;
+                return false;
             }
 
             case MemoryProtectionLevel::TMR: {
                 // TMR can repair using majority voting
-                size_t chunk_size = size;
-                uint8_t* copy1 = mem_ptr;
-                uint8_t* copy2 = mem_ptr + chunk_size;
-                uint8_t* copy3 = mem_ptr + 2 * chunk_size;
+                uint8_t* copy1 = user;
+                uint8_t* copy2 = user + size;
+                uint8_t* copy3 = user + 2 * size;
 
-                // Repair using majority voting
-                for (size_t i = 0; i < chunk_size; ++i) {
-                    // Find correct value using majority voting
-                    uint8_t correct_value = majorityVote(copy1[i], copy2[i], copy3[i]);
+                for (size_t i = 0; i < size; ++i) {
+                    const uint8_t correct_value = majorityVote(copy1[i], copy2[i], copy3[i]);
 
-                    // Repair any copies that differ from majority
                     if (copy1[i] != correct_value) {
                         copy1[i] = correct_value;
                         repaired = true;
@@ -1011,6 +934,18 @@ class UnifiedMemoryManager {
             default:
                 return false;
         }
+    }
+
+    /**
+     * @brief Compute the parity of a byte (1 if odd number of set bits)
+     */
+    static uint8_t byteParity(uint8_t byte)
+    {
+        uint8_t parity = 0;
+        for (int bit = 0; bit < 8; ++bit) {
+            parity ^= ((byte >> bit) & 1);
+        }
+        return parity;
     }
 
     /**
@@ -1207,6 +1142,7 @@ class RadiationTolerantPtr {
     void reset(T* ptr = nullptr) noexcept
     {
         if (ptr_ != nullptr) {
+            ptr_->~T();  // Objects are placement-constructed in make()/makeProtected()
             UnifiedMemoryManager::getInstance().deallocate(ptr_);
         }
         ptr_ = ptr;
@@ -1297,6 +1233,11 @@ class RadiationTolerantPtr {
             throw;
         }
 
+        // Re-arm protection so CRC/TMR/ECC metadata reflects the constructed
+        // object rather than the uninitialized allocation
+        auto level = UnifiedMemoryManager::getInstance().getDefaultProtectionLevel();
+        UnifiedMemoryManager::getInstance().protectMemory(ptr, level);
+
         return RadiationTolerantPtr<U>(ptr);
     }
 
@@ -1328,6 +1269,10 @@ class RadiationTolerantPtr {
             UnifiedMemoryManager::getInstance().deallocate(ptr);
             throw;
         }
+
+        // Re-arm protection so CRC/TMR/ECC metadata reflects the constructed
+        // object rather than the uninitialized allocation
+        UnifiedMemoryManager::getInstance().protectMemory(ptr, protection_level);
 
         return RadiationTolerantPtr<U>(ptr);
     }

--- a/include/rad_ml/core/redundancy/enhanced_voting.hpp
+++ b/include/rad_ml/core/redundancy/enhanced_voting.hpp
@@ -286,6 +286,93 @@ public:
     }
     
     /**
+     * CRC-32 checksum (polynomial 0xEDB88320), bitwise implementation.
+     *
+     * Intended for computing a write-time checksum of a value so that voting
+     * can later distinguish intact copies from corrupted ones.
+     *
+     * @param data Pointer to the data
+     * @param length Length of the data in bytes
+     * @return CRC-32 checksum
+     */
+    static uint32_t crc32(const void* data, size_t length) noexcept {
+        uint32_t crc = 0xFFFFFFFF;
+        const uint8_t* bytes = static_cast<const uint8_t*>(data);
+        for (size_t i = 0; i < length; i++) {
+            crc ^= bytes[i];
+            for (int j = 0; j < 8; j++) {
+                crc = (crc >> 1) ^ (0xEDB88320u & (~(crc & 1u) + 1u));
+            }
+        }
+        return ~crc;
+    }
+
+    /**
+     * Convenience overload: CRC-32 of a trivially copyable value.
+     */
+    template <typename T>
+    static uint32_t crc32(const T& value) noexcept {
+        static_assert(std::is_trivially_copyable<T>::value,
+                      "crc32 requires a trivially copyable type");
+        return crc32(&value, sizeof(T));
+    }
+
+    /**
+     * Checksum-assisted adaptive voting.
+     *
+     * @param expected_checksum CRC-32 of the value computed at write time
+     *        (before any corruption), e.g. the per-copy checksums EnhancedTMR
+     *        stores on set(). It is used as an oracle in two ways:
+     *        1. A copy whose current CRC matches is provably unmodified since
+     *           the write (modulo a ~2^-32 collision) and is returned
+     *           directly. This resolves cases plain voting gets wrong, such
+     *           as correlated corruption of two copies outvoting the single
+     *           intact copy at the bit level.
+     *        2. If every copy is corrupted, reconstruction candidates from
+     *           bit-level, word-error and burst-error voting are validated
+     *           against the checksum; a validating candidate recovered the
+     *           original value exactly.
+     *        If neither applies, falls back to plain pattern-based
+     *        adaptiveVote().
+     *
+     * @param a First copy
+     * @param b Second copy
+     * @param c Third copy
+     * @param pattern The detected or expected fault pattern
+     * @return Best value based on checksum validation and specialized voting
+     */
+#if __cplusplus >= 202002L
+    template<VotableType T>
+#else
+    template<typename T>
+#endif
+    static T adaptiveVote(const T& a, const T& b, const T& c, FaultPattern pattern,
+                          uint32_t expected_checksum) {
+        // Fast path: all copies agree
+        if (a == b && b == c) return a;
+
+        // 1. Trust any copy that still matches its write-time checksum. This
+        //    intentionally precedes pairwise agreement: two agreeing copies
+        //    can both be corrupted by a correlated upset, while a validating
+        //    copy is known-good.
+        if (crc32(a) == expected_checksum) return a;
+        if (crc32(b) == expected_checksum) return b;
+        if (crc32(c) == expected_checksum) return c;
+
+        // 2. All copies corrupted: try to reconstruct the original and
+        //    validate each candidate against the checksum.
+        const T bit_result = bitLevelVote(a, b, c);
+        if (crc32(bit_result) == expected_checksum) return bit_result;
+        const T word_result = wordErrorVote(a, b, c);
+        if (crc32(word_result) == expected_checksum) return word_result;
+        const T burst_result = burstErrorVote(a, b, c);
+        if (crc32(burst_result) == expected_checksum) return burst_result;
+
+        // 3. Nothing validates: fall back to pattern-based voting
+        return adaptiveVote(a, b, c, pattern);
+    }
+
+    /**
      * Detect the most likely fault pattern based on bit differences
      * 
      * @param a First copy

--- a/include/rad_ml/neural/fine_tuning.hpp
+++ b/include/rad_ml/neural/fine_tuning.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <fstream>
 #include <functional>
 #include <iomanip>
@@ -1289,9 +1290,11 @@ private:
                 size_t weight_idx = weight_dist(gen);
                 int bit_idx = bit_dist(gen);
 
-                // Flip bit
-                uint32_t* bits = reinterpret_cast<uint32_t*>(&corrupted_weights[weight_idx]);
-                *bits ^= (1U << bit_idx);
+                // Flip bit via memcpy to avoid strict-aliasing UB
+                uint32_t bits;
+                std::memcpy(&bits, &corrupted_weights[weight_idx], sizeof(bits));
+                bits ^= (1U << bit_idx);
+                std::memcpy(&corrupted_weights[weight_idx], &bits, sizeof(bits));
             }
 
             // Calculate error rate (fraction of weights corrupted)

--- a/include/rad_ml/testing/fault_injection.hpp
+++ b/include/rad_ml/testing/fault_injection.hpp
@@ -14,10 +14,11 @@
 #include <random>
 #include <map>
 #include <cstdint>
-#include <bitset>
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <memory>
+#include <type_traits>
 
 namespace rad_ml {
 namespace testing {
@@ -141,43 +142,64 @@ private:
     std::mt19937 gen;  // Mersenne Twister random generator
 };
 
+namespace detail {
+
+/// Unsigned integer type with the same size as T, used as a bit container
+template<typename T>
+using BitsOf = typename std::conditional<
+    sizeof(T) == 1, std::uint8_t,
+    typename std::conditional<
+        sizeof(T) == 2, std::uint16_t,
+        typename std::conditional<
+            sizeof(T) == 4, std::uint32_t,
+            std::uint64_t
+        >::type
+    >::type>::type;
+
+} // namespace detail
+
 /**
  * Template implementation for injectFault
+ *
+ * Bit manipulation is done on an unsigned integer copy of the value's object
+ * representation (via std::memcpy) to avoid strict-aliasing undefined
+ * behavior; bit i corresponds to bit i of the value's memory representation.
  */
 template<typename T>
 T SystematicFaultInjector::injectFault(T value, FaultPattern pattern, int bit_position) {
     static_assert(std::is_arithmetic<T>::value, "Only arithmetic types are supported");
-    
+    static_assert(sizeof(T) <= 8, "Types larger than 64 bits are not supported");
+
+    using Bits = detail::BitsOf<T>;
     constexpr int total_bits = sizeof(T) * 8;
-    
+
     // For random bit position
     if (bit_position < 0) {
         std::uniform_int_distribution<> dis(0, total_bits - 1);
         bit_position = dis(gen);
     }
-    
+
     // Get the bits to flip based on the pattern
     std::vector<int> bits_to_flip = getBitsToFlip(pattern, total_bits, bit_position);
-    
-    // Convert to bitset for manipulation
-    std::bitset<sizeof(T) * 8> bits = 
-        *reinterpret_cast<std::bitset<sizeof(T) * 8>*>(&value);
-    
+
+    Bits bits = 0;
+    std::memcpy(&bits, &value, sizeof(T));
+
     // Apply the bit flips
     for (int bit : bits_to_flip) {
         if (bit >= 0 && bit < total_bits) {
+            const Bits mask = Bits{1} << bit;
             if (pattern == STUCK_AT_ZERO) {
-                bits.reset(bit);  // Set to 0
+                bits &= static_cast<Bits>(~mask);  // Set to 0
             } else if (pattern == STUCK_AT_ONE) {
-                bits.set(bit);    // Set to 1
+                bits |= mask;                      // Set to 1
             } else {
-                bits.flip(bit);   // Flip bit
+                bits ^= mask;                      // Flip bit
             }
         }
     }
-    
-    // Convert back to the original type
-    value = *reinterpret_cast<T*>(&bits);
+
+    std::memcpy(&value, &bits, sizeof(T));
     return value;
 }
 

--- a/include/rad_ml/tmr/enhanced_tmr.hpp
+++ b/include/rad_ml/tmr/enhanced_tmr.hpp
@@ -336,6 +336,24 @@ class EnhancedTMR {
     }
 
     /**
+     * @brief Corrupt a specific copy without re-arming its CRC (for testing)
+     *
+     * Unlike setRawCopy(), this models a radiation upset: the in-memory copy
+     * changes but the stored write-time CRC does not, so CRC verification and
+     * checksum-assisted voting can detect the corruption.
+     *
+     * @param index Index of the copy (0-2)
+     * @param value Corrupted value
+     */
+    void corruptCopy(size_t index, const T& value)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (index < num_copies_) {
+            copies_[index] = value;
+        }
+    }
+
+    /**
      * @brief Force verification of all copies
      *
      * @return True if verification passed, false if errors detected
@@ -585,6 +603,41 @@ class EnhancedTMR {
 
         // We have a disagreement
         voting_disagreements_++;
+
+        // Checksum-assisted selection: a copy whose current CRC still matches
+        // its stored write-time CRC is provably unmodified, so prefer it over
+        // agreement heuristics (two agreeing copies can both be corrupted by
+        // a correlated upset). Only applies when the CRCs discriminate
+        // between copies; if all copies validate (e.g. every change went
+        // through set()/setRawCopy(), which re-arm the CRC) the checksum
+        // carries no information and we fall through to regular voting.
+        {
+            bool crc_ok[num_copies_];
+            size_t ok_count = 0;
+            for (size_t i = 0; i < num_copies_; i++) {
+                crc_ok[i] = (crc_calculator_.calculate(&copies_[i], sizeof(T)) == crcs_[i]);
+                if (crc_ok[i]) ok_count++;
+            }
+
+            if (ok_count > 0 && ok_count < num_copies_) {
+                size_t best_idx = num_copies_;
+                for (size_t i = 0; i < num_copies_; i++) {
+                    if (crc_ok[i] &&
+                        (best_idx == num_copies_ || health_scores_[i] > health_scores_[best_idx])) {
+                        best_idx = i;
+                    }
+                }
+                for (size_t i = 0; i < num_copies_; i++) {
+                    if (crc_ok[i]) {
+                        health_scores_[i] = std::min(1.0, health_scores_[i] + 0.05);
+                    }
+                    else {
+                        health_scores_[i] = std::max(0.1, health_scores_[i] - 0.2);
+                    }
+                }
+                return copies_[best_idx];
+            }
+        }
 
         if (use_health_weighted_voting_) {
             // Health-weighted voting

--- a/include/rad_ml/utils/bit_manipulation.hpp
+++ b/include/rad_ml/utils/bit_manipulation.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <cmath>
 #include <limits>
 #include <type_traits>
@@ -33,18 +34,15 @@ public:
             return value; // Invalid bit position
         }
         
-        // Use union to reinterpret float as uint32_t for bit manipulation
-        union {
-            float f;
-            uint32_t i;
-        } converter;
-        
-        converter.f = value;
+        // Copy bits into an integer via memcpy (union punning is UB in C++)
+        uint32_t bits;
+        std::memcpy(&bits, &value, sizeof(value));
         
         // Flip the specified bit using XOR
-        converter.i ^= (1u << bit_position);
+        bits ^= (1u << bit_position);
         
-        return converter.f;
+        std::memcpy(&value, &bits, sizeof(value));
+        return value;
     }
     
     /**
@@ -59,18 +57,15 @@ public:
             return value; // Invalid bit position
         }
         
-        // Use union to reinterpret double as uint64_t for bit manipulation
-        union {
-            double d;
-            uint64_t i;
-        } converter;
-        
-        converter.d = value;
+        // Copy bits into an integer via memcpy (union punning is UB in C++)
+        uint64_t bits;
+        std::memcpy(&bits, &value, sizeof(value));
         
         // Flip the specified bit using XOR
-        converter.i ^= (1ULL << bit_position);
+        bits ^= (1ULL << bit_position);
         
-        return converter.d;
+        std::memcpy(&value, &bits, sizeof(value));
+        return value;
     }
     
     /**
@@ -84,7 +79,7 @@ public:
     template<typename T>
     static typename std::enable_if<std::is_integral<T>::value, T>::type
     flipBit(T value, int bit_position) {
-        if (bit_position < 0 || bit_position >= sizeof(T) * 8) {
+        if (bit_position < 0 || bit_position >= static_cast<int>(sizeof(T) * 8)) {
             return value; // Invalid bit position
         }
         
@@ -114,16 +109,16 @@ public:
             >::type
         >::type;
         
-        union {
-            T value;
-            UIntType bits;
-        } a_conv, b_conv;
+        static_assert(sizeof(UIntType) == sizeof(T),
+                      "Only 1, 2, 4, and 8 byte types are supported");
         
-        a_conv.value = a;
-        b_conv.value = b;
+        UIntType a_bits = 0;
+        UIntType b_bits = 0;
+        std::memcpy(&a_bits, &a, sizeof(T));
+        std::memcpy(&b_bits, &b, sizeof(T));
         
         // XOR the values to get bits that differ
-        UIntType diff = a_conv.bits ^ b_conv.bits;
+        UIntType diff = a_bits ^ b_bits;
         
         // Count the bits set in the difference
         int count = 0;
@@ -145,7 +140,7 @@ public:
      */
     template<typename T>
     static bool isBitSet(T value, int bit_position) {
-        if (bit_position < 0 || bit_position >= sizeof(T) * 8) {
+        if (bit_position < 0 || bit_position >= static_cast<int>(sizeof(T) * 8)) {
             return false; // Invalid bit position
         }
         
@@ -154,14 +149,12 @@ public:
             using UIntType = typename std::conditional<
                 sizeof(T) == 8, uint64_t, uint32_t
             >::type;
+            static_assert(sizeof(UIntType) == sizeof(T),
+                          "Unsupported floating-point size");
             
-            union {
-                T value;
-                UIntType bits;
-            } converter;
-            
-            converter.value = value;
-            return (converter.bits & (static_cast<UIntType>(1) << bit_position)) != 0;
+            UIntType bits;
+            std::memcpy(&bits, &value, sizeof(T));
+            return (bits & (static_cast<UIntType>(1) << bit_position)) != 0;
         }
         else {
             return (value & (static_cast<T>(1) << bit_position)) != 0;

--- a/test/unit/core/memory/unified_memory_test.cpp
+++ b/test/unit/core/memory/unified_memory_test.cpp
@@ -1,0 +1,254 @@
+/**
+ * @file unified_memory_test.cpp
+ * @brief Regression tests for UnifiedMemoryManager protection lifecycle
+ *
+ * Covers the allocate -> corrupt -> verify -> deallocate path for every
+ * concrete protection level (CANARY, CRC, ECC, TMR). These paths were
+ * previously broken:
+ *  - CANARY allocations were tracked by the raw pointer but users received an
+ *    offset pointer, so deallocate() failed lookup and leaked
+ *  - is_protected/protection_level were never recorded, so integrity checks
+ *    never ran
+ *  - verifyMemoryIntegrity() used the global default protection level instead
+ *    of the allocation's own level, and deadlocked when called from
+ *    deallocate()
+ *  - CRC checksums were computed but never stored or compared
+ */
+
+#include <rad_ml/core/memory/unified_memory.hpp>
+#include <rad_ml/utils/bit_manipulation.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+using rad_ml::memory::MemoryFlags;
+using rad_ml::memory::MemoryProtectionLevel;
+using rad_ml::memory::UnifiedMemoryManager;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* what)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << what << "\n";
+        ++failures;
+    }
+}
+
+UnifiedMemoryManager& manager() { return UnifiedMemoryManager::getInstance(); }
+
+void test_unprotected_roundtrip()
+{
+    void* ptr = manager().allocate(64);
+    check(ptr != nullptr, "unprotected allocate returns memory");
+    check(manager().isAllocated(ptr), "unprotected allocation is tracked");
+    check(manager().verifyMemoryIntegrity(ptr), "unprotected verify is a no-op success");
+    check(manager().deallocate(ptr), "unprotected deallocate succeeds");
+    check(!manager().isAllocated(ptr), "deallocated pointer is no longer tracked");
+    check(!manager().deallocate(ptr), "double free is rejected");
+}
+
+void test_canary_roundtrip_and_detection()
+{
+    constexpr size_t size = 32;
+    auto* ptr = static_cast<uint8_t*>(
+        manager().allocate(size, MemoryFlags::DEFAULT, MemoryProtectionLevel::CANARY));
+    check(ptr != nullptr, "CANARY allocate returns memory");
+    check(manager().isAllocated(ptr), "CANARY allocation is tracked by the user pointer");
+
+    const auto* info = manager().getAllocationInfo(ptr);
+    check(info != nullptr, "CANARY allocation info is available");
+    if (info) {
+        check(info->is_protected.load(), "CANARY allocation is marked protected");
+        check(info->protection_level == MemoryProtectionLevel::CANARY,
+              "CANARY allocation records its protection level");
+        check(info->original_ptr != static_cast<void*>(ptr),
+              "CANARY user pointer is offset from the raw allocation");
+    }
+
+    // Writing the entire user region must not disturb the canaries
+    std::memset(ptr, 0xAB, size);
+    check(manager().verifyMemoryIntegrity(ptr), "CANARY verify passes after user writes");
+
+    // Buffer overflow: clobber the trailing canary
+    ptr[size] ^= 0xFF;
+    check(!manager().verifyMemoryIntegrity(ptr), "CANARY verify detects overflow");
+    ptr[size] ^= 0xFF;
+    check(manager().verifyMemoryIntegrity(ptr), "CANARY verify passes after restore");
+
+    // Buffer underflow: clobber the leading canary
+    ptr[-1] ^= 0xFF;
+    check(!manager().verifyMemoryIntegrity(ptr), "CANARY verify detects underflow");
+
+    // This was the original bug: deallocate must find the allocation via the
+    // user pointer (and must free the raw pointer, not the offset one)
+    check(manager().deallocate(ptr), "CANARY deallocate succeeds despite corruption");
+    check(!manager().isAllocated(ptr), "CANARY allocation is untracked after free");
+}
+
+void test_canary_aligned_allocation()
+{
+    constexpr size_t alignment = 64;
+    void* ptr = manager().allocate(100, MemoryFlags::ALIGNED, MemoryProtectionLevel::CANARY,
+                                   "aligned canary test", alignment);
+    check(ptr != nullptr, "aligned CANARY allocate returns memory");
+    check(reinterpret_cast<uintptr_t>(ptr) % alignment == 0,
+          "aligned CANARY user pointer honors the requested alignment");
+    check(manager().verifyMemoryIntegrity(ptr), "aligned CANARY verify passes");
+    check(manager().deallocate(ptr), "aligned CANARY deallocate succeeds");
+}
+
+void test_crc_detects_bit_flip()
+{
+    constexpr size_t size = 48;
+    auto* ptr = static_cast<uint8_t*>(
+        manager().allocate(size, MemoryFlags::ZERO_INITIALIZED, MemoryProtectionLevel::CRC));
+    check(ptr != nullptr, "CRC allocate returns memory");
+    check(manager().verifyMemoryIntegrity(ptr), "CRC verify passes right after allocation");
+
+    // Legitimate write followed by re-arming the checksum
+    for (size_t i = 0; i < size; ++i) {
+        ptr[i] = static_cast<uint8_t>(i * 7);
+    }
+    check(manager().protectMemory(ptr, MemoryProtectionLevel::CRC),
+          "CRC protection can be re-armed after writes");
+    check(manager().verifyMemoryIntegrity(ptr), "CRC verify passes after re-arm");
+
+    // Simulated SEU: single bit flip must now be detected (previously the
+    // stored CRC did not exist and verification always passed)
+    ptr[13] ^= 0x04;
+    check(!manager().verifyMemoryIntegrity(ptr), "CRC verify detects a single bit flip");
+    ptr[13] ^= 0x04;
+    check(manager().verifyMemoryIntegrity(ptr), "CRC verify passes after restoring the bit");
+
+    // Changing to a different concrete protection level would overflow the
+    // reserved metadata space and must be rejected
+    check(!manager().protectMemory(ptr, MemoryProtectionLevel::TMR),
+          "changing protection level after allocation is rejected");
+
+    check(manager().deallocate(ptr), "CRC deallocate succeeds");
+}
+
+void test_ecc_detects_bit_flip()
+{
+    constexpr size_t size = 16;
+    auto* ptr = static_cast<uint8_t*>(
+        manager().allocate(size, MemoryFlags::ZERO_INITIALIZED, MemoryProtectionLevel::ECC));
+    check(ptr != nullptr, "ECC allocate returns memory");
+
+    for (size_t i = 0; i < size; ++i) {
+        ptr[i] = static_cast<uint8_t>(0x30 + i);
+    }
+    check(manager().protectMemory(ptr, MemoryProtectionLevel::ECC),
+          "ECC protection can be re-armed after writes");
+    check(manager().verifyMemoryIntegrity(ptr), "ECC verify passes after re-arm");
+
+    ptr[5] ^= 0x10;
+    check(!manager().verifyMemoryIntegrity(ptr), "ECC verify detects a single bit flip");
+
+    check(manager().deallocate(ptr), "ECC deallocate succeeds despite corruption");
+}
+
+void test_tmr_detects_divergent_copy()
+{
+    constexpr size_t size = 24;
+    auto* ptr = static_cast<uint8_t*>(
+        manager().allocate(size, MemoryFlags::ZERO_INITIALIZED, MemoryProtectionLevel::TMR));
+    check(ptr != nullptr, "TMR allocate returns memory");
+
+    for (size_t i = 0; i < size; ++i) {
+        ptr[i] = static_cast<uint8_t>(0xC0 - i);
+    }
+    check(manager().protectMemory(ptr, MemoryProtectionLevel::TMR),
+          "TMR protection can be re-armed after writes");
+    check(manager().verifyMemoryIntegrity(ptr), "TMR verify passes after re-arm");
+
+    // Corrupt one byte in the second copy
+    ptr[size + 3] ^= 0x01;
+    check(!manager().verifyMemoryIntegrity(ptr), "TMR verify detects a divergent copy");
+
+    // Deallocation repairs via majority vote and must still succeed
+    check(manager().deallocate(ptr), "TMR deallocate succeeds despite corruption");
+}
+
+void test_corruption_callback_fires()
+{
+    int callback_count = 0;
+    size_t id = manager().registerCorruptionCallback(
+        [&callback_count](void*, size_t, const std::string&) { ++callback_count; });
+
+    auto* ptr = static_cast<uint8_t*>(
+        manager().allocate(8, MemoryFlags::ZERO_INITIALIZED, MemoryProtectionLevel::CANARY));
+    ptr[8] ^= 0xFF;  // Clobber trailing canary
+    manager().verifyMemoryIntegrity(ptr);
+    check(callback_count == 1, "corruption callback fires on detection");
+
+    ptr[8] ^= 0xFF;
+    check(manager().deallocate(ptr), "callback test allocation deallocates");
+    check(manager().unregisterCorruptionCallback(id), "corruption callback unregisters");
+}
+
+void test_stats_track_protected_allocations()
+{
+    const auto before = manager().getStats();
+
+    void* ptr = manager().allocate(16, MemoryFlags::DEFAULT, MemoryProtectionLevel::CANARY);
+    auto during = manager().getStats();
+    check(during.protected_allocations == before.protected_allocations + 1,
+          "protected allocation count increments");
+    check(during.current_allocations == before.current_allocations + 1,
+          "current allocation count increments");
+
+    manager().deallocate(ptr);
+    auto after = manager().getStats();
+    check(after.protected_allocations == before.protected_allocations,
+          "protected allocation count returns to baseline");
+    check(after.current_allocations == before.current_allocations,
+          "current allocation count returns to baseline");
+}
+
+void test_bit_manipulation_roundtrip()
+{
+    using rad_ml::utils::BitManipulation;
+
+    const float f = 3.14159f;
+    const float f_flipped = BitManipulation::flipBit(f, 7);
+    check(f != f_flipped, "float bit flip changes the value");
+    check(BitManipulation::flipBit(f_flipped, 7) == f, "float double flip restores the value");
+    check(BitManipulation::countBitDifferences(f, f_flipped) == 1,
+          "float single flip differs by exactly one bit");
+
+    const double d = -2.718281828;
+    const double d_flipped = BitManipulation::flipBit(d, 55);
+    check(BitManipulation::flipBit(d_flipped, 55) == d, "double double flip restores the value");
+    check(BitManipulation::countBitDifferences(d, d_flipped) == 1,
+          "double single flip differs by exactly one bit");
+
+    check(BitManipulation::isBitSet(uint32_t{0b1000}, 3), "isBitSet finds a set integer bit");
+    check(!BitManipulation::isBitSet(uint32_t{0b1000}, 2), "isBitSet rejects a clear integer bit");
+}
+
+}  // namespace
+
+int main()
+{
+    test_unprotected_roundtrip();
+    test_canary_roundtrip_and_detection();
+    test_canary_aligned_allocation();
+    test_crc_detects_bit_flip();
+    test_ecc_detects_bit_flip();
+    test_tmr_detects_divergent_copy();
+    test_corruption_callback_fires();
+    test_stats_track_protected_allocations();
+    test_bit_manipulation_roundtrip();
+
+    if (failures == 0) {
+        std::cout << "All unified_memory_test checks passed.\n";
+        return 0;
+    }
+    std::cerr << failures << " check(s) failed.\n";
+    return 1;
+}

--- a/test/unit/core/redundancy/checksum_voting_test.cpp
+++ b/test/unit/core/redundancy/checksum_voting_test.cpp
@@ -1,0 +1,174 @@
+/**
+ * @file checksum_voting_test.cpp
+ * @brief Regression tests for checksum-assisted adaptive voting
+ *
+ * Covers the CRC-assisted selection paths added to:
+ *  - EnhancedVoting::adaptiveVote(a, b, c, pattern, expected_checksum):
+ *    trusts a copy whose CRC matches the write-time checksum, validates
+ *    reconstruction candidates when all copies are corrupted, and falls back
+ *    to plain pattern voting when nothing validates.
+ *  - EnhancedTMR::performWeightedVoting(): when copies disagree and the
+ *    stored per-copy CRCs discriminate between intact and corrupted copies,
+ *    the intact copy wins even against two agreeing (correlated-corrupted)
+ *    copies.
+ */
+
+#include <rad_ml/core/redundancy/enhanced_voting.hpp>
+#include <rad_ml/tmr/enhanced_tmr.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+using rad_ml::core::redundancy::EnhancedVoting;
+using rad_ml::core::redundancy::FaultPattern;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* what)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << what << "\n";
+        ++failures;
+    }
+}
+
+template <typename T>
+T flipBit(T value, int bit)
+{
+    using UintType = typename std::conditional<sizeof(T) <= 4, uint32_t, uint64_t>::type;
+    UintType bits;
+    std::memcpy(&bits, &value, sizeof(T));
+    bits ^= (UintType(1) << bit);
+    T result;
+    std::memcpy(&result, &bits, sizeof(T));
+    return result;
+}
+
+template <typename T>
+T adaptiveWithChecksum(const T& original, const T& a, const T& b, const T& c)
+{
+    const FaultPattern pattern = EnhancedVoting::detectFaultPattern(a, b, c);
+    return EnhancedVoting::adaptiveVote(a, b, c, pattern, EnhancedVoting::crc32(original));
+}
+
+void test_all_agree_fast_path()
+{
+    const float value = 3.14159f;
+    check(adaptiveWithChecksum(value, value, value, value) == value,
+          "all-agree fast path returns the value");
+}
+
+void test_intact_copy_beats_correlated_majority()
+{
+    // Two copies corrupted with the same 4-bit pattern at adjacent offsets
+    // (mirrors the CORRELATED_ERRORS Monte Carlo scenario). Bit-level
+    // majority voting loses the overlapping bits, but the intact copy's CRC
+    // validates.
+    const uint32_t original = 0x12345678u;
+    uint32_t a = original ^ (0xFu << 8);
+    uint32_t b = original ^ (0xFu << 9);
+    uint32_t c = original;
+
+    check(adaptiveWithChecksum(original, a, b, c) == original,
+          "intact copy is selected under correlated corruption");
+
+    // Plain (checksum-free) adaptive voting gets this wrong: the three
+    // overlapping corrupted bits outvote the intact copy. This documents the
+    // gap the checksum closes; if plain voting ever starts passing, the
+    // scenario is no longer exercising the fallback.
+    const FaultPattern pattern = EnhancedVoting::detectFaultPattern(a, b, c);
+    check(EnhancedVoting::adaptiveVote(a, b, c, pattern) != original,
+          "plain adaptive voting loses this case (documents the gap)");
+}
+
+void test_identical_corruption_of_two_copies()
+{
+    // Both corrupted copies are bit-identical, so they form a (wrong)
+    // majority. Only the checksum identifies the intact copy.
+    const double original = -2.718281828;
+    const double corrupted = flipBit(original, 17);
+
+    check(adaptiveWithChecksum(original, corrupted, corrupted, original) == original,
+          "CRC-validating copy beats two identically corrupted copies");
+}
+
+void test_reconstruction_candidate_validation()
+{
+    // All three copies corrupted at distinct bit positions: no copy
+    // validates, but bit-level majority reconstructs the original and the
+    // checksum confirms it.
+    const uint32_t original = 0xCAFEBABEu;
+    const uint32_t a = flipBit(original, 3);
+    const uint32_t b = flipBit(original, 14);
+    const uint32_t c = flipBit(original, 27);
+
+    check(adaptiveWithChecksum(original, a, b, c) == original,
+          "validated bit-level reconstruction recovers from all-copy corruption");
+}
+
+void test_fallback_when_nothing_validates()
+{
+    // With a checksum that matches nothing, the result must equal plain
+    // pattern-based adaptive voting.
+    const uint32_t a = flipBit(0xDEADBEEFu, 1);
+    const uint32_t b = flipBit(0xDEADBEEFu, 2);
+    const uint32_t c = flipBit(0xDEADBEEFu, 3);
+    const FaultPattern pattern = EnhancedVoting::detectFaultPattern(a, b, c);
+
+    const uint32_t with_bogus_crc = EnhancedVoting::adaptiveVote(a, b, c, pattern, 0u);
+    const uint32_t plain = EnhancedVoting::adaptiveVote(a, b, c, pattern);
+    check(with_bogus_crc == plain, "non-validating checksum falls back to plain adaptive voting");
+}
+
+void test_enhanced_tmr_crc_assisted_voting()
+{
+    // Radiation-style corruption (corruptCopy does not re-arm the CRC) of
+    // two copies with identical values: they agree, but their CRCs fail
+    // while copy 2 validates, so the intact copy must win.
+    const float original = 42.5f;
+    rad_ml::tmr::EnhancedTMR<float> tmr(original);
+
+    const float corrupted = flipBit(original, 30);
+    tmr.corruptCopy(0, corrupted);
+    tmr.corruptCopy(1, corrupted);
+
+    check(tmr.get() == original,
+          "EnhancedTMR returns the CRC-validating copy over an agreeing corrupted pair");
+
+    // Divergent corruption of two copies: all three disagree, only copy 1
+    // validates.
+    rad_ml::tmr::EnhancedTMR<float> tmr2(original);
+    tmr2.corruptCopy(0, flipBit(original, 5));
+    tmr2.corruptCopy(2, flipBit(original, 22));
+
+    check(tmr2.get() == original,
+          "EnhancedTMR recovers from divergent double-copy corruption via CRC");
+
+    // setRawCopy re-arms the CRC, so the checksum carries no information and
+    // the existing majority logic must still handle single-copy corruption.
+    rad_ml::tmr::EnhancedTMR<float> tmr3(original);
+    tmr3.setRawCopy(0, flipBit(original, 9));
+    check(tmr3.get() == original, "setRawCopy corruption is still recovered by majority voting");
+}
+
+}  // namespace
+
+int main()
+{
+    test_all_agree_fast_path();
+    test_intact_copy_beats_correlated_majority();
+    test_identical_corruption_of_two_copies();
+    test_reconstruction_candidate_validation();
+    test_fallback_when_nothing_validates();
+    test_enhanced_tmr_crc_assisted_voting();
+
+    if (failures == 0) {
+        std::cout << "All checksum voting tests passed.\n";
+        return 0;
+    }
+    std::cerr << failures << " checksum voting test(s) failed.\n";
+    return 1;
+}

--- a/test/unit/testing/fault_injection_bits_test.cpp
+++ b/test/unit/testing/fault_injection_bits_test.cpp
@@ -1,0 +1,115 @@
+/**
+ * @file fault_injection_bits_test.cpp
+ * @brief Regression test for SystematicFaultInjector::injectFault bit semantics
+ *
+ * injectFault previously reinterpret_cast the value as a std::bitset, which is
+ * undefined behavior and relies on an unspecified internal layout. It now
+ * operates on a memcpy'd unsigned integer; these tests pin down the intended
+ * semantics: bit i of the injected fault corresponds to bit i of the value's
+ * object representation.
+ */
+
+#include <rad_ml/testing/fault_injection.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+using rad_ml::testing::SystematicFaultInjector;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* what)
+{
+    if (!condition) {
+        std::cerr << "FAILED: " << what << "\n";
+        ++failures;
+    }
+}
+
+template <typename T>
+uint64_t bitsOf(T value)
+{
+    uint64_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(T));
+    return bits;
+}
+
+void test_single_bit_flip_int()
+{
+    SystematicFaultInjector injector;
+
+    const int original = 0x12345678;
+    const int corrupted = injector.injectFault(original, SystematicFaultInjector::SINGLE_BIT, 4);
+
+    check(corrupted == (original ^ (1 << 4)), "SINGLE_BIT flips exactly the requested bit");
+
+    const int restored = injector.injectFault(corrupted, SystematicFaultInjector::SINGLE_BIT, 4);
+    check(restored == original, "flipping the same bit twice restores the value");
+}
+
+void test_single_bit_flip_float()
+{
+    SystematicFaultInjector injector;
+
+    const float original = 42.125f;
+    const float corrupted =
+        injector.injectFault(original, SystematicFaultInjector::SINGLE_BIT, 21);
+
+    check((bitsOf(original) ^ bitsOf(corrupted)) == (1ull << 21),
+          "float SINGLE_BIT changes exactly bit 21 of the representation");
+
+    const float restored =
+        injector.injectFault(corrupted, SystematicFaultInjector::SINGLE_BIT, 21);
+    check(bitsOf(restored) == bitsOf(original), "float double flip restores the representation");
+}
+
+void test_stuck_at_semantics()
+{
+    SystematicFaultInjector injector;
+
+    const uint8_t all_ones = 0xFF;
+    const uint8_t stuck_zero =
+        injector.injectFault(all_ones, SystematicFaultInjector::STUCK_AT_ZERO, 3);
+    check((stuck_zero & (1 << 3)) == 0, "STUCK_AT_ZERO clears the requested bit");
+
+    const uint8_t all_zeros = 0x00;
+    const uint8_t stuck_one =
+        injector.injectFault(all_zeros, SystematicFaultInjector::STUCK_AT_ONE, 6);
+    check((stuck_one & (1 << 6)) != 0, "STUCK_AT_ONE sets the requested bit");
+
+    // Stuck-at faults are idempotent
+    check(injector.injectFault(stuck_one, SystematicFaultInjector::STUCK_AT_ONE, 6) == stuck_one,
+          "STUCK_AT_ONE is idempotent");
+}
+
+void test_double_precision_supported()
+{
+    SystematicFaultInjector injector;
+
+    const double original = -1.5e300;
+    const double corrupted =
+        injector.injectFault(original, SystematicFaultInjector::SINGLE_BIT, 52);
+
+    check((bitsOf(original) ^ bitsOf(corrupted)) == (1ull << 52),
+          "double SINGLE_BIT changes exactly bit 52 of the representation");
+}
+
+}  // namespace
+
+int main()
+{
+    test_single_bit_flip_int();
+    test_single_bit_flip_float();
+    test_stuck_at_semantics();
+    test_double_precision_supported();
+
+    if (failures == 0) {
+        std::cout << "All fault_injection_bits_test checks passed.\n";
+        return 0;
+    }
+    std::cerr << failures << " check(s) failed.\n";
+    return 1;
+}

--- a/test/verification/monte_carlo_validation.cpp
+++ b/test/verification/monte_carlo_validation.cpp
@@ -762,11 +762,16 @@ void runMonteCarloValidation(std::mt19937& gen,
                     test_results.burst_error_success++;
                 }
 
-                // 5. Adaptive Voting
+                // 5. Adaptive Voting (checksum-assisted). The CRC-32 models
+                // the write-time checksum a protection container stores when
+                // the value is written (as EnhancedTMR does per copy); the
+                // voter uses it to identify intact copies or validate
+                // reconstruction candidates when all copies are corrupted.
                 FaultPattern detected_pattern =
                     EnhancedVoting::detectFaultPattern(copy1, copy2, copy3);
-                T adaptive_result =
-                    EnhancedVoting::adaptiveVote(copy1, copy2, copy3, detected_pattern);
+                const uint32_t write_time_crc = EnhancedVoting::crc32(original_value);
+                T adaptive_result = EnhancedVoting::adaptiveVote(copy1, copy2, copy3,
+                                                                 detected_pattern, write_time_crc);
                 if (adaptive_result == original_value) {
                     test_results.adaptive_success++;
                 }
@@ -1527,6 +1532,235 @@ void printSummaryResults(const std::map<std::string, std::map<std::string, TestR
     std::cout << "---------------------------------------------------------\n";
 }
 
+// ============================================================================
+// Threshold gates
+//
+// The process exits non-zero if any headline protection metric regresses, so
+// CTest actually defends the published numbers. Thresholds are set with
+// margin below the rates measured after the July 2026 correctness fixes
+// (voting methods ~99.999%, recovery correction 100%, best challenging-
+// scenario method 100%) so Monte Carlo noise does not cause flaky failures,
+// while real regressions (e.g. re-enabling -ffast-math, breaking voting or
+// repair logic) trip the gate.
+// ============================================================================
+
+namespace {
+
+struct GateAggregates {
+    std::map<std::string, double> method_avg;  // Average rate per method (standard scenarios)
+    double recovery_detection = 0.0;
+    double recovery_correction = 0.0;
+    double recovery_uncorrectable = 0.0;
+    double multi_corruption_best = 0.0;       // Best method under multi-copy corruption
+    double correlated_errors_best = 0.0;      // Best method under correlated errors
+    double multi_corruption_adaptive = 0.0;   // Adaptive voting under multi-copy corruption
+    double correlated_errors_adaptive = 0.0;  // Adaptive voting under correlated errors
+    double edge_cases_adaptive = 0.0;
+    bool has_data = false;
+};
+
+GateAggregates computeGateAggregates(
+    const std::map<std::string, std::map<std::string, TestResults>>& results)
+{
+    GateAggregates agg;
+
+    const std::vector<std::string> actual_types = {typeid(float).name(), typeid(double).name(),
+                                                   typeid(int32_t).name(), typeid(int64_t).name()};
+    const std::vector<std::string> error_types = {"SINGLE_BIT", "MULTI_BIT", "BURST", "WORD",
+                                                  "COMBINED"};
+
+    int standard_count = 0;
+    int recovery_count = 0;
+    int multi_count = 0;
+    int correlated_count = 0;
+    int edge_count = 0;
+
+    for (const auto& actual_type : actual_types) {
+        auto type_it = results.find(actual_type);
+        if (type_it == results.end()) continue;
+        const auto& per_key = type_it->second;
+
+        for (const auto& env : ENVIRONMENTS) {
+            // Standard scenarios: per-method average rates
+            for (const auto& error_type : error_types) {
+                auto it = per_key.find(env.name + "_" + error_type);
+                if (it == per_key.end() || it->second.total_trials == 0) continue;
+                const auto& r = it->second;
+                const double n = static_cast<double>(r.total_trials);
+
+                agg.method_avg["Standard"] += r.standard_success / n;
+                agg.method_avg["Bit-Level"] += r.bit_level_success / n;
+                agg.method_avg["Word-Error"] += r.word_error_success / n;
+                agg.method_avg["Burst-Error"] += r.burst_error_success / n;
+                agg.method_avg["Adaptive"] += r.adaptive_success / n;
+                agg.method_avg["Weighted Voting"] += r.weighted_voting_success / n;
+                agg.method_avg["Fast Bit Correction"] += r.fast_bit_correction_success / n;
+                agg.method_avg["Pattern Detection"] += r.pattern_detection_success / n;
+                agg.method_avg["Protected Value"] += r.protected_value_success / n;
+                agg.method_avg["Aligned Memory"] += r.aligned_memory_success / n;
+                standard_count++;
+            }
+
+            // Recovery scenario
+            if (auto it = per_key.find(env.name + "_RECOVERY_TEST");
+                it != per_key.end() && it->second.total_trials > 0) {
+                const auto& r = it->second;
+                const double n = static_cast<double>(r.total_trials);
+                agg.recovery_detection += r.recovery_detected / n;
+                // Two recovery phases per trial (see RECOVERY_TEST implementation)
+                agg.recovery_correction += r.recovery_corrected / (2.0 * n);
+                agg.recovery_uncorrectable += r.recovery_uncorrectable / (2.0 * n);
+                recovery_count++;
+            }
+
+            // Challenging scenarios: gate on the best method, since plain
+            // majority voting is expected to degrade under multi-copy and
+            // correlated corruption
+            auto best_rate = [](const TestResults& r) {
+                const double n = static_cast<double>(r.total_trials);
+                double best = 0.0;
+                for (double rate :
+                     {r.weighted_voting_success / n, r.pattern_detection_success / n,
+                      r.protected_value_success / n, r.aligned_memory_success / n,
+                      r.adaptive_success / n}) {
+                    best = std::max(best, rate);
+                }
+                return best;
+            };
+
+            if (auto it = per_key.find(env.name + "_MULTI_CORRUPTION");
+                it != per_key.end() && it->second.total_trials > 0) {
+                const auto& r = it->second;
+                agg.multi_corruption_best += best_rate(r);
+                agg.multi_corruption_adaptive +=
+                    r.adaptive_success / static_cast<double>(r.total_trials);
+                multi_count++;
+            }
+            if (auto it = per_key.find(env.name + "_CORRELATED_ERRORS");
+                it != per_key.end() && it->second.total_trials > 0) {
+                const auto& r = it->second;
+                agg.correlated_errors_best += best_rate(r);
+                agg.correlated_errors_adaptive +=
+                    r.adaptive_success / static_cast<double>(r.total_trials);
+                correlated_count++;
+            }
+            if (auto it = per_key.find(env.name + "_EDGE_CASES");
+                it != per_key.end() && it->second.total_trials > 0) {
+                const auto& r = it->second;
+                agg.edge_cases_adaptive +=
+                    r.adaptive_success / static_cast<double>(r.total_trials);
+                edge_count++;
+            }
+        }
+    }
+
+    if (standard_count > 0) {
+        for (auto& [name, sum] : agg.method_avg) {
+            sum /= standard_count;
+        }
+        agg.has_data = true;
+    }
+    if (recovery_count > 0) {
+        agg.recovery_detection /= recovery_count;
+        agg.recovery_correction /= recovery_count;
+        agg.recovery_uncorrectable /= recovery_count;
+    }
+    if (multi_count > 0) {
+        agg.multi_corruption_best /= multi_count;
+        agg.multi_corruption_adaptive /= multi_count;
+    }
+    if (correlated_count > 0) {
+        agg.correlated_errors_best /= correlated_count;
+        agg.correlated_errors_adaptive /= correlated_count;
+    }
+    if (edge_count > 0) agg.edge_cases_adaptive /= edge_count;
+
+    return agg;
+}
+
+/// Returns the number of failed gates (0 = all pass)
+int evaluateThresholdGates(
+    const std::map<std::string, std::map<std::string, TestResults>>& results)
+{
+    const GateAggregates agg = computeGateAggregates(results);
+
+    std::cout << "\n=== Threshold Gates ===\n";
+
+    if (!agg.has_data) {
+        std::cout << "GATE FAILURE: no test results were collected\n";
+        return 1;
+    }
+
+    int failures = 0;
+    auto gate_min = [&failures](const std::string& name, double measured, double threshold) {
+        const bool ok = measured >= threshold;
+        std::cout << (ok ? "  [PASS] " : "  [FAIL] ") << name << ": " << std::fixed
+                  << std::setprecision(4) << measured * 100 << "% (required >= "
+                  << threshold * 100 << "%)\n";
+        if (!ok) failures++;
+    };
+    auto gate_max = [&failures](const std::string& name, double measured, double threshold) {
+        const bool ok = measured <= threshold;
+        std::cout << (ok ? "  [PASS] " : "  [FAIL] ") << name << ": " << std::fixed
+                  << std::setprecision(4) << measured * 100 << "% (required <= "
+                  << threshold * 100 << "%)\n";
+        if (!ok) failures++;
+    };
+    auto gate_band = [&failures](const std::string& name, double measured, double lo, double hi) {
+        const bool ok = measured >= lo && measured <= hi;
+        std::cout << (ok ? "  [PASS] " : "  [FAIL] ") << name << ": " << std::fixed
+                  << std::setprecision(4) << measured * 100 << "% (required "
+                  << lo * 100 << "% - " << hi * 100 << "%)\n";
+        if (!ok) failures++;
+    };
+
+    // Voting methods on standard scenarios (measured ~99.999%)
+    for (const char* method : {"Standard", "Bit-Level", "Word-Error", "Burst-Error", "Adaptive",
+                               "Weighted Voting", "Fast Bit Correction", "Pattern Detection",
+                               "Protected Value", "Aligned Memory"}) {
+        gate_min(std::string(method) + " (standard scenarios)", agg.method_avg.at(method), 0.999);
+    }
+
+    // Recovery pipeline (measured: detection 100%, correction 100%)
+    gate_min("Recovery detection", agg.recovery_detection, 0.999);
+    gate_min("Recovery correction", agg.recovery_correction, 0.995);
+    gate_max("Recovery uncorrectable", agg.recovery_uncorrectable, 0.005);
+
+    // Challenging scenarios: at least one protection method must hold up
+    gate_min("Multi-copy corruption (best method)", agg.multi_corruption_best, 0.99);
+    gate_min("Correlated errors (best method)", agg.correlated_errors_best, 0.99);
+    gate_min("Edge cases (adaptive voting)", agg.edge_cases_adaptive, 0.99);
+
+    // Adaptive voting under multi-copy corruption is band-gated: measured
+    // ~56% as of July 2026. A drop means the voting logic regressed; a jump
+    // above the band most likely means the scenario stopped injecting real
+    // multi-copy corruption (a broken test reading as an improvement).
+    // Checksum-assisted voting does NOT move this number: all three copies
+    // are corrupted, so no copy CRC-validates, and the residual failures are
+    // same-bit collisions across copies that no reconstruction can undo. If a
+    // genuine algorithmic improvement raises this rate, re-baseline the band
+    // deliberately.
+    gate_band("Multi-copy corruption (adaptive voting)", agg.multi_corruption_adaptive, 0.45,
+              0.70);
+
+    // Re-baselined July 2026: checksum-assisted adaptive voting (write-time
+    // CRC identifies the intact copy) raised correlated-error recovery from
+    // ~21% to ~100%; the scenario always leaves one copy intact, and that
+    // copy now provably wins the vote. Previously band-gated at 12%-35%.
+    gate_min("Correlated errors (adaptive voting)", agg.correlated_errors_adaptive, 0.99);
+
+    if (failures == 0) {
+        std::cout << "All threshold gates passed.\n";
+    }
+    else {
+        std::cout << failures << " threshold gate(s) FAILED - validation regressed.\n";
+    }
+
+    return failures;
+}
+
+}  // namespace
+
 int main()
 {
     std::cout << "=================================================================\n";
@@ -1578,5 +1812,7 @@ int main()
     // Generate NASA-style verification report
     generateVerificationReport(all_results);
 
-    return 0;
+    // Fail the process if headline metrics regressed, so CTest can gate on it
+    const int gate_failures = evaluateThresholdGates(all_results);
+    return gate_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary by Sourcery

Strengthen memory protection, voting, and fault-injection correctness, add checksum-assisted TMR voting, and gate Monte Carlo validation with quantitative thresholds while extending tests and APIs.

New Features:
- Add checksum-assisted adaptive voting using CRC-32 to identify intact TMR copies and validate reconstructed values.
- Expose EnhancedTMR CRC-assisted selection and a corruptCopy helper to model radiation upsets in tests.
- Introduce a ProtectedNetwork helper struct and updated createProtectedNetwork API to pair networks with their selective-hardening engines.
- Provide a higher-level radiation simulator factory that configures PhysicsRadiationSimulator from SpaceEnvironment parameters.

Bug Fixes:
- Fix UnifiedMemoryManager to track user-facing pointers correctly, honor per-allocation protection levels, and validate/frees protected allocations without leaks or deadlocks.
- Correct CANARY, CRC, ECC, and TMR metadata layout so integrity checks and repair use the allocation’s actual scheme instead of the global default.
- Eliminate strict-aliasing undefined behavior in bit-level operations and fault injection by using memcpy-based bit access.
- Ensure RadiationTolerantPtr destroys placement-constructed objects before deallocation and re-arms protection after construction so metadata matches live objects.

Enhancements:
- Refine protection metadata management with explicit header/trailer sizing, centralized setup/verify/repair helpers, and concrete protection detection.
- Improve ECC and TMR verification/repair semantics, including clearer parity handling and majority-vote repair logic.
- Document and enforce that protection levels cannot be changed after allocation once metadata space is fixed.
- Clarify neural selective-hardening configuration by wiring the hardening strategy into HardeningConfig and recording requested protection levels.
- Add CRC-32 utility in EnhancedVoting for trivially copyable types to support checksum-based integrity decisions.
- Tighten Monte Carlo validation by computing aggregate protection metrics and enforcing threshold gates that fail the test run on regression.

Build:
- Remove -ffast-math from optimized compiler flags to preserve IEEE-754 semantics required by NaN/Inf-aware TMR voting.
- Add unit test targets for UnifiedMemoryManager protection lifecycle, checksum-assisted voting, and fault-injection bit semantics to CMake.

Documentation:
- Inline comments and test descriptions now document checksum-assisted voting behavior, protection metadata layout, threshold-gate rationale, and the removal of -ffast-math.

Tests:
- Add unified_memory_test to cover end-to-end protection lifecycle and stats for CANARY, CRC, ECC, and TMR allocations plus corruption callbacks.
- Add checksum_voting_test to exercise CRC-assisted EnhancedVoting adaptiveVote and EnhancedTMR CRC-aware selection under realistic corruption patterns.
- Add fault_injection_bits_test to pin down bit-exact semantics of SystematicFaultInjector::injectFault for integers and floating-point types.
- Extend Monte Carlo validation to compute aggregated method and recovery metrics and introduce threshold gates that cause the test binary to fail on regressions.